### PR TITLE
fix: use glibc binary in workspace image instead of musl

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -85,3 +85,5 @@ jobs:
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            OPENCODE_VERSION=${{ github.ref_name }}

--- a/images/workspace/Dockerfile
+++ b/images/workspace/Dockerfile
@@ -3,12 +3,35 @@
 # developer environment on glibc (Debian) with git, compilers, and common
 # CLI tools so hosted OpenCode sessions can actually build, test, and commit.
 #
-ARG OPENCODE_IMAGE=ghcr.io/anomalyco/opencode:latest
+# We download the glibc release tarballs directly because the musl-linked
+# binary from the stock Alpine image won't run on Debian/glibc.
+#
+ARG OPENCODE_VERSION=latest
 
 # ---------------------------------------------------------------------------
-# Stage 1: Extract the opencode binary from the stock image
+# Stage 1: Download the glibc opencode binary
 # ---------------------------------------------------------------------------
-FROM ${OPENCODE_IMAGE} AS opencode-bin
+FROM alpine:3.21 AS opencode-bin
+
+ARG OPENCODE_VERSION
+ARG TARGETARCH
+
+RUN apk add --no-cache curl && \
+    if [ "$TARGETARCH" = "amd64" ]; then \
+      ARCH="x64"; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+      ARCH="arm64"; \
+    else \
+      echo "Unsupported arch: $TARGETARCH" && exit 1; \
+    fi && \
+    if [ "$OPENCODE_VERSION" = "latest" ]; then \
+      URL="https://github.com/anomalyco/opencode/releases/latest/download/opencode-linux-${ARCH}.tar.gz"; \
+    else \
+      URL="https://github.com/anomalyco/opencode/releases/download/${OPENCODE_VERSION}/opencode-linux-${ARCH}.tar.gz"; \
+    fi && \
+    echo "Downloading $URL" && \
+    curl -fSL "$URL" | tar xzf - -C /usr/local/bin opencode && \
+    chmod +x /usr/local/bin/opencode
 
 # ---------------------------------------------------------------------------
 # Stage 2: Developer-ready base


### PR DESCRIPTION
## Summary

- **Root cause**: The `opencode-workspace` Dockerfile copied the binary from `ghcr.io/anomalyco/opencode:latest` (Alpine/musl) into `debian:bookworm-slim` (glibc). The musl-linked binary fails with exit code 127 on glibc systems.
- **Fix**: Stage 1 now downloads the glibc release tarball directly from GitHub releases (`opencode-linux-x64.tar.gz` / `opencode-linux-arm64.tar.gz`), using `TARGETARCH` (auto-set by buildx) to select the correct arch.
- **Workflow**: Passes `OPENCODE_VERSION=${{ github.ref_name }}` as a build arg to pin the release version during tag-triggered builds.

## Changes

| File | Change |
|---|---|
| `images/workspace/Dockerfile` | Replace `FROM ghcr.io/anomalyco/opencode` with Alpine stage that downloads glibc tarball |
| `.github/workflows/publish-images.yml` | Add `build-args: OPENCODE_VERSION` for version pinning |

## Verification

The failed run `23866676168` showed:
```
/bin/sh: 1: opencode: not found
```
at `Dockerfile:57` — this fix resolves that by using a glibc-compatible binary.