### PR TITLE
fix: run workspace as non-root, mount PVC at /home/opencode

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -24,6 +24,13 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        runAsNonRoot: {{ .Values.securityContext.runAsNonRoot }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
+        runAsGroup: {{ .Values.securityContext.runAsGroup }}
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -44,7 +51,7 @@ spec:
           if [ -d /identity ]; then
             for f in /identity/*; do
               filename=$(basename "$f")
-              target="/workspace/$filename"
+              target="/home/opencode/$filename"
               if [ ! -e "$target" ]; then
                 cp "$f" "$target"
               fi
@@ -55,7 +62,7 @@ spec:
           mountPath: /identity
           readOnly: true
         - name: workspace
-          mountPath: /workspace
+          mountPath: /home/opencode
       {{- end }}
       containers:
       - name: opencode
@@ -67,6 +74,8 @@ spec:
           name: http
           protocol: TCP
         env:
+        - name: HOME
+          value: "/home/opencode"
         - name: OPENCODE_SERVER_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -108,11 +117,11 @@ spec:
         {{- end }}
         volumeMounts:
         - name: config
-          mountPath: /root/.config/opencode
+          mountPath: /home/opencode/.config/opencode
         - name: data
-          mountPath: /root/.local/share/opencode
+          mountPath: /home/opencode/.local/share/opencode
         - name: workspace
-          mountPath: /workspace
+          mountPath: /home/opencode
         {{- with .Values.extraVolumeMounts }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -35,6 +35,13 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
+      {{- if $root.Values.securityContext.enabled }}
+      securityContext:
+        runAsNonRoot: {{ $root.Values.securityContext.runAsNonRoot }}
+        runAsUser: {{ $root.Values.securityContext.runAsUser }}
+        runAsGroup: {{ $root.Values.securityContext.runAsGroup }}
+        fsGroup: {{ $root.Values.securityContext.fsGroup }}
+      {{- end }}
       {{- with $root.Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -55,7 +62,7 @@ spec:
           if [ -d /identity ]; then
             for f in /identity/*; do
               filename=$(basename "$f")
-              target="/workspace/$filename"
+              target="/home/opencode/$filename"
               if [ ! -e "$target" ]; then
                 cp "$f" "$target"
               fi
@@ -66,7 +73,7 @@ spec:
           mountPath: /identity
           readOnly: true
         - name: workspace
-          mountPath: /workspace
+          mountPath: /home/opencode
       {{- end }}
       containers:
       - name: opencode
@@ -78,6 +85,8 @@ spec:
           name: http
           protocol: TCP
         env:
+        - name: HOME
+          value: "/home/opencode"
         - name: OPENCODE_SERVER_PASSWORD
           valueFrom:
             secretKeyRef:
@@ -119,11 +128,11 @@ spec:
         {{- end }}
         volumeMounts:
         - name: config
-          mountPath: /root/.config/opencode
+          mountPath: /home/opencode/.config/opencode
         - name: data
-          mountPath: /root/.local/share/opencode
+          mountPath: /home/opencode/.local/share/opencode
         - name: workspace
-          mountPath: /workspace
+          mountPath: /home/opencode
         {{- with $root.Values.extraVolumeMounts }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -223,6 +223,15 @@ resources:
     cpu: "2"
     memory: 2Gi
 
+# -- Pod security context for the OpenCode container
+# -- Runs as non-root user (UID 1000) for security best practices
+securityContext:
+  enabled: true
+  runAsNonRoot: true
+  runAsUser: 1000
+  runAsGroup: 1000
+  fsGroup: 1000
+
 # -- Node selector (defaults to arm64)
 nodeSelector:
   kubernetes.io/arch: arm64

--- a/images/workspace/Dockerfile
+++ b/images/workspace/Dockerfile
@@ -79,6 +79,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY --from=opencode-bin /usr/local/bin/opencode /usr/local/bin/opencode
 RUN chmod +x /usr/local/bin/opencode && opencode --version
 
-WORKDIR /workspace
+# Create non-root user for security
+RUN groupadd -g 1000 opencode && \
+    useradd -u 1000 -g 1000 -m -d /home/opencode -s /bin/bash opencode && \
+    chown -R opencode:opencode /home/opencode
+
+ENV HOME=/home/opencode
+
+USER opencode
+WORKDIR /home/opencode
 
 ENTRYPOINT ["opencode"]


### PR DESCRIPTION
## Summary
- **Non-root container**: Added `opencode` user (UID 1000) to Dockerfile, `USER opencode`, `securityContext` with `runAsNonRoot: true`
- **Workspace as home directory**: PVC mounted at `/home/opencode` instead of `/workspace` — terminal opens directly into the workspace (like Codespaces/Gitpod)
- **Removed `workingDir` override**: `$HOME` is now the workspace, no extra config needed

## Changes
- `images/workspace/Dockerfile` — create non-root user, `WORKDIR /home/opencode`
- `chart/values.yaml` — new `securityContext` section
- `chart/templates/deployment.yaml` — securityContext, HOME env, all mounts under `/home/opencode`
- `chart/templates/statefulset.yaml` — same for multi-user mode

## Verification
- `helm lint` passes
- `helm template` renders correct mount paths (all `/home/opencode`)