### PR TITLE
fix: correct OCI chart paths in docs, add publish verification

### DIFF
--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -33,3 +33,11 @@ jobs:
 
       - name: Push chart
         run: helm push ok8s-*.tgz oci://ghcr.io/timothyclin/k8s-opencode/chart
+
+      - name: Verify chart is fetchable
+        run: |
+          VERSION=$(echo ${{ github.ref_name }} | sed 's/v//')
+          echo "Verifying chart version $VERSION is fetchable..."
+          helm pull oci://ghcr.io/timothyclin/k8s-opencode/chart/ok8s --version $VERSION --untar-only --untar-dir verify-test || exit 1
+          rm -rf verify-test
+          echo "Chart verified successfully"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@ OpenCode + Oh-My-OpenCode on Kubernetes with Tailscale connectivity and Kubedock
 
 The chart and container images are published to GitHub Container Registry (GHCR):
 
-- **Chart**: `oci://ghcr.io/timothyclin/k8s-opencode/chart/ok8s/ok8s`
+- **Chart**: `oci://ghcr.io/timothyclin/k8s-opencode/chart/ok8s`
 - **Workspace image**: `ghcr.io/timothyclin/k8s-opencode/opencode-workspace`
 - **Auth router image**: `ghcr.io/timothyclin/k8s-opencode/auth-router`
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -383,7 +383,7 @@ mcp:
       port: 3000
 ```
 
-4. Upgrade: `helm upgrade ok8s oci://ghcr.io/timothyclin/k8s-opencode/chart/ok8s/ok8s -n opencode -f values.yaml`
+4. Upgrade: `helm upgrade ok8s oci://ghcr.io/timothyclin/k8s-opencode/chart/ok8s -n opencode -f values.yaml`
 
 ### Add Team-Wide Skills (Multi-User)
 
@@ -464,7 +464,7 @@ what values map to what JSON output.
 3. MCP servers under `mcp.remote` or `mcp.laptopServers`
 4. Extra skills under `skills.npm` or `skills.config`
 5. Any extra env vars under `extraEnv`
-6. Apply: `helm upgrade ok8s oci://ghcr.io/timothyclin/k8s-opencode/chart/ok8s/ok8s -n opencode -f values.yaml`
+6. Apply: `helm upgrade ok8s oci://ghcr.io/timothyclin/k8s-opencode/chart/ok8s -n opencode -f values.yaml`
 
 ### Multi-User Configuration Checklist
 
@@ -475,7 +475,7 @@ what values map to what JSON output.
 5. Shared skills under `sharedSkills.npm` / `sharedSkills.config`
 6. Per-user MCP servers under `users[].mcp.remote` / `users[].mcp.laptopServers`
 7. Per-user skills under `users[].skills.npm` / `users[].skills.config`
-8. Apply: `helm upgrade ok8s oci://ghcr.io/timothyclin/k8s-opencode/chart/ok8s/ok8s -n opencode -f values.yaml`
+8. Apply: `helm upgrade ok8s oci://ghcr.io/timothyclin/k8s-opencode/chart/ok8s -n opencode -f values.yaml`
 
 ### Verifying the Generated Config
 


### PR DESCRIPTION
## Summary
- Fix docs/customization.md: remove duplicate `/ok8s` from OCI paths (was `chart/ok8s/ok8s` → `chart/ok8s`)
- Fix docs/architecture.md: same fix for chart reference
- Add post-publish verification step to publish-chart.yml that pulls the chart after pushing to verify it's fetchable

## Root Cause
1. Original workflow pushed to wrong path `k8s-omo` (later fixed)
2. Docs had typos with double `/ok8s` in some files
3. No verification step to catch publish failures

## Prevention
This adds a verification step that runs `helm pull` after push to confirm the chart is actually fetchable before marking the workflow as successful.