### PR TITLE
fix: init container sets ownership on PVC mounts before main container runs

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: ok8s
 description: OpenCode + Oh-My-OpenCode on Kubernetes with Tailscale connectivity
 type: application
-version: 0.1.2
-appVersion: "0.1.2"
+version: 0.1.3
+appVersion: "0.1.3"
 keywords:
   - opencode
   - ai-coding

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -48,21 +48,35 @@ spec:
         - sh
         - -c
         - |
+          set -e
+          # Ensure workspace directory exists and has correct permissions
+          if [ -d /home/opencode/workspace ]; then
+            chown -R 1000:1000 /home/opencode/workspace
+          fi
+          # Copy identity files if present
           if [ -d /identity ]; then
             for f in /identity/*; do
               filename=$(basename "$f")
               target="/home/opencode/$filename"
               if [ ! -e "$target" ]; then
-                cp "$f" "$target"
+                cp -r "$f" "$target"
+                chown -R 1000:1000 "$target"
               fi
             done
           fi
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
         volumeMounts:
         - name: identity
           mountPath: /identity
           readOnly: true
         - name: workspace
           mountPath: /home/opencode/workspace
+        - name: data
+          mountPath: /home/opencode/.local/share/opencode
+        - name: config
+          mountPath: /home/opencode/.config/opencode
       {{- end }}
       containers:
       - name: opencode

--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -59,21 +59,35 @@ spec:
         - sh
         - -c
         - |
+          set -e
+          # Ensure workspace directory exists and has correct permissions
+          if [ -d /home/opencode/workspace ]; then
+            chown -R 1000:1000 /home/opencode/workspace
+          fi
+          # Copy identity files if present
           if [ -d /identity ]; then
             for f in /identity/*; do
               filename=$(basename "$f")
               target="/home/opencode/$filename"
               if [ ! -e "$target" ]; then
-                cp "$f" "$target"
+                cp -r "$f" "$target"
+                chown -R 1000:1000 "$target"
               fi
             done
           fi
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
         volumeMounts:
         - name: identity
           mountPath: /identity
           readOnly: true
         - name: workspace
           mountPath: /home/opencode/workspace
+        - name: data
+          mountPath: /home/opencode/.local/share/opencode
+        - name: config
+          mountPath: /home/opencode/.config/opencode
       {{- end }}
       containers:
       - name: opencode

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,7 +1,7 @@
 # -- OpenCode container image
 image:
   repository: ghcr.io/timothyclin/k8s-opencode/opencode-workspace
-  tag: "0.1.2"
+  tag: "0.1.3"
   pullPolicy: IfNotPresent
 
 # -- Create the release namespace (set to false if installing into an existing namespace)


### PR DESCRIPTION
## Summary
- Fix `EACCES: permission denied, mkdir '/home/opencode/.local/state'` error
- The init container now runs as root (`securityContext.runAsUser: 0`) and:
  - Changes ownership of `/home/opencode/workspace` to UID 1000
  - Copies identity files with correct ownership
- This ensures the main container (running as UID 1000) can write to the mounted PVCs
- Bumped chart version to 0.1.3

## Root Cause
The PVCs are mounted at `/home/opencode/workspace`, `/home/opencode/.local/share/opencode`, and `/home/opencode/.config/opencode`. These come from NFS with root ownership, but the main container runs as non-root user (UID 1000). The init container needs to fix ownership before the main container starts.

## Changes
- deployment.yaml: init container now runs as root, chowns workspace dir, mounts all volumes
- statefulset.yaml: same fix for multi-user mode
- Chart.yaml/values.yaml: version bump to 0.1.3