### PR TITLE
fix: always run init container to fix PVC permissions for non-root user

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: ok8s
 description: OpenCode + Oh-My-OpenCode on Kubernetes with Tailscale connectivity
 type: application
-version: 0.1.3
-appVersion: "0.1.3"
+version: 0.1.4
+appVersion: "0.1.4"
 keywords:
   - opencode
   - ai-coding

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -39,6 +39,30 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      # Always run init container to fix PVC permissions (runs as root)
+      initContainers:
+      - name: init-permissions
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+        - sh
+        - -c
+        - |
+          set -e
+          # Fix ownership on all mounted directories
+          chown -R 1000:1000 /home/opencode/workspace /home/opencode/.local /home/opencode/.config 2>/dev/null || true
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+        volumeMounts:
+        - name: workspace
+          mountPath: /home/opencode/workspace
+        - name: data
+          mountPath: /home/opencode/.local/share/opencode
+          subPath: ..
+        - name: config
+          mountPath: /home/opencode/.config/opencode
+          subPath: ..
       {{- if .Values.identity.enabled }}
       initContainers:
       - name: init-identity

--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -50,6 +50,30 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      # Always run init container to fix PVC permissions (runs as root)
+      initContainers:
+      - name: init-permissions
+        image: "{{ $root.Values.image.repository }}:{{ $root.Values.image.tag }}"
+        imagePullPolicy: {{ $root.Values.image.pullPolicy }}
+        command:
+        - sh
+        - -c
+        - |
+          set -e
+          # Fix ownership on all mounted directories
+          chown -R 1000:1000 /home/opencode/workspace /home/opencode/.local /home/opencode/.config 2>/dev/null || true
+        securityContext:
+          runAsUser: 0
+          runAsGroup: 0
+        volumeMounts:
+        - name: workspace
+          mountPath: /home/opencode/workspace
+        - name: data
+          mountPath: /home/opencode/.local/share/opencode
+          subPath: ..
+        - name: config
+          mountPath: /home/opencode/.config/opencode
+          subPath: ..
       {{- if $root.Values.identity.enabled }}
       initContainers:
       - name: init-identity

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -1,7 +1,7 @@
 # -- OpenCode container image
 image:
   repository: ghcr.io/timothyclin/k8s-opencode/opencode-workspace
-  tag: "0.1.3"
+  tag: "0.1.4"
   pullPolicy: IfNotPresent
 
 # -- Create the release namespace (set to false if installing into an existing namespace)


### PR DESCRIPTION
## Summary
- Fix `EACCES: permission denied, mkdir '/home/opencode/.local/state'` error
- **Always** run an init container (not conditional on identity.enabled) to fix PVC ownership
- Init container runs as root (`runAsUser: 0`) and chowns all mounted directories to UID 1000
- Works for both Deployment (single-user) and StatefulSet (multi-user)
- Bumped version to 0.1.4

## Root Cause
The previous fix only added the init container when `identity.enabled: true`. But users who don't use identity files still need the permissions fix. The init container must run unconditionally.