### PR TITLE
fix: mount config from PVC instead of ConfigMap to allow writes

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -54,6 +54,15 @@ spec:
           # Create opencode subdirectory if it doesn't exist (main app needs it)
           mkdir -p /home/opencode/.config/opencode 2>/dev/null || true
           chown -R 1000:1000 /home/opencode/.config/opencode 2>/dev/null || true
+          # Copy config files from ConfigMap to PVC (ConfigMap is read-only, need to copy to writable PVC)
+          if [ -f /etc/opencode-config/opencode.jsonc ]; then
+            cp /etc/opencode-config/opencode.jsonc /home/opencode/.config/opencode/
+            chown 1000:1000 /home/opencode/.config/opencode/opencode.jsonc
+          fi
+          if [ -f /etc/opencode-config/oh-my-opencode.jsonc ]; then
+            cp /etc/opencode-config/oh-my-opencode.jsonc /home/opencode/.config/opencode/
+            chown 1000:1000 /home/opencode/.config/opencode/oh-my-opencode.jsonc
+          fi
         securityContext:
           runAsUser: 0
           runAsGroup: 0
@@ -62,6 +71,9 @@ spec:
           runAsNonRoot: false
           {{- end }}
         volumeMounts:
+        - name: config-src
+          mountPath: /etc/opencode-config
+          readOnly: true
         - name: workspace
           mountPath: /home/opencode/workspace
         - name: data
@@ -69,7 +81,6 @@ spec:
         - name: config
           mountPath: /home/opencode/.config
       {{- if .Values.identity.enabled }}
-      initContainers:
       - name: init-identity
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -97,6 +108,9 @@ spec:
           runAsUser: 0
           runAsGroup: 0
         volumeMounts:
+        - name: config-src
+          mountPath: /etc/opencode-config
+          readOnly: true
         - name: identity
           mountPath: /identity
           readOnly: true
@@ -160,12 +174,15 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         volumeMounts:
-        - name: config
-          mountPath: /home/opencode/.config
-        - name: data
-          mountPath: /home/opencode/.local
+        - name: config-src
+          mountPath: /etc/opencode-config
+          readOnly: true
         - name: workspace
           mountPath: /home/opencode/workspace
+        - name: data
+          mountPath: /home/opencode/.local
+        - name: config
+          mountPath: /home/opencode/.config
         {{- with .Values.extraVolumeMounts }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -184,9 +201,12 @@ spec:
         resources:
           {{- toYaml .Values.resources | nindent 10 }}
       volumes:
-      - name: config
+      - name: config-src
         configMap:
           name: {{ include "ok8s.fullname" . }}-config
+      - name: config
+        persistentVolumeClaim:
+          claimName: {{ include "ok8s.fullname" . }}-config
       - name: data
         persistentVolumeClaim:
           claimName: {{ include "ok8s.fullname" . }}-data

--- a/chart/templates/pvc.yaml
+++ b/chart/templates/pvc.yaml
@@ -2,6 +2,23 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
+  name: {{ include "ok8s.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ok8s.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.data.accessMode }}
+  {{- if .Values.persistence.data.storageClass }}
+  storageClassName: {{ .Values.persistence.data.storageClass }}
+  {{- end }}
+  resources:
+    requests:
+      storage: 100Mi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
   name: {{ include "ok8s.fullname" . }}-data
   namespace: {{ .Release.Namespace }}
   labels:

--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -62,6 +62,18 @@ spec:
           set -e
           # Fix ownership on all mounted directories
           chown -R 1000:1000 /home/opencode/workspace /home/opencode/.local /home/opencode/.config 2>/dev/null || true
+          # Create opencode subdirectory if it doesn't exist (main app needs it)
+          mkdir -p /home/opencode/.config/opencode 2>/dev/null || true
+          chown -R 1000:1000 /home/opencode/.config/opencode 2>/dev/null || true
+          # Copy config files from ConfigMap to PVC (ConfigMap is read-only, need to copy to writable PVC)
+          if [ -f /etc/opencode-config/opencode.jsonc ]; then
+            cp /etc/opencode-config/opencode.jsonc /home/opencode/.config/opencode/
+            chown 1000:1000 /home/opencode/.config/opencode/opencode.jsonc
+          fi
+          if [ -f /etc/opencode-config/oh-my-opencode.jsonc ]; then
+            cp /etc/opencode-config/oh-my-opencode.jsonc /home/opencode/.config/opencode/
+            chown 1000:1000 /home/opencode/.config/opencode/oh-my-opencode.jsonc
+          fi
         securityContext:
           runAsUser: 0
           runAsGroup: 0
@@ -69,12 +81,16 @@ spec:
           runAsNonRoot: false
           {{- end }}
         volumeMounts:
+        - name: config-src
+          mountPath: /etc/opencode-config
+          readOnly: true
         - name: workspace
           mountPath: /home/opencode/workspace
         - name: data
           mountPath: /home/opencode/.local
+        - name: config
+          mountPath: /home/opencode/.config
       {{- if $root.Values.identity.enabled }}
-      initContainers:
       - name: init-identity
         image: "{{ $root.Values.image.repository }}:{{ $root.Values.image.tag }}"
         imagePullPolicy: {{ $root.Values.image.pullPolicy }}
@@ -102,6 +118,9 @@ spec:
           runAsUser: 0
           runAsGroup: 0
         volumeMounts:
+        - name: config-src
+          mountPath: /etc/opencode-config
+          readOnly: true
         - name: identity
           mountPath: /identity
           readOnly: true
@@ -111,7 +130,6 @@ spec:
           mountPath: /home/opencode/.local
         - name: config
           mountPath: /home/opencode/.config
-          subPath: opencode
       {{- end }}
       containers:
       - name: opencode
@@ -191,7 +209,7 @@ spec:
         resources:
           {{- toYaml (default $root.Values.resources $user.resources) | nindent 10 }}
       volumes:
-      - name: config
+      - name: config-src
         configMap:
           name: {{ include "ok8s.fullname" $root }}-user-{{ $user.name }}-config
       {{- if $root.Values.identity.enabled }}


### PR DESCRIPTION
## Summary

- Fix: ConfigMap is read-only, cannot create /home/opencode/.config/opencode directory
- Mount config volume from PVC instead of ConfigMap
- Init container copies config files from ConfigMap to writable PVC

## Changes

- deployment.yaml: Add config-src volume (ConfigMap), mount at /etc/opencode-config
- deployment.yaml: config volume now uses PVC, init copies config files
- pvc.yaml: Add separate config PVC (100Mi)
- statefulset.yaml: Same changes for multi-user mode