### PR TITLE
feat: enable default MCPs, skills, and Oh-My-OpenCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,12 +129,12 @@ See [chart/values.yaml](chart/values.yaml) for all options. Key sections:
 
 ### Enabling Oh-My-OpenCode, Skills, MCPs, and Plugins
 
-By default, the chart installs OpenCode with **no plugins, skills, or MCP servers**. To enable them, add the following to your values file:
+By default, the chart enables Oh-My-OpenCode, Context7 MCP, and user skills. To disable or customize, add the following to your values file:
 
 ```yaml
-# Enable Oh-My-OpenCode (task orchestration, specialized agents)
+# Disable Oh-My-OpenCode (task orchestration, specialized agents)
 omo:
-  enabled: true
+  enabled: false
   sisyphus:
     maxConcurrentTasks: 2
     taskTimeout: 300
@@ -150,30 +150,19 @@ omo:
     visualEngineering:
       model: "github-copilot/claude-sonnet-4.6"
 
-# Install npm skills (optional)
+# Override default skills (defaults: CORE, Prompting, Art, CreateSkill, Agents, GitWorkflow)
 skills:
   npm: []
-  # Example: ["@my-org/skills@latest"]
   config: []
 
-# Configure MCP servers (optional)
+# Override default MCP servers (default: context7)
 mcp:
   remote: []
-  # Example:
-  # - name: context7
-  #   url: https://mcp.context7.com/mcp
-  #   enabled: true
   laptopServers: []
-  # Example:
-  # - name: playwright
-  #   tailscaleIP: "100.x.x.x"
-  #   port: 3000
 
-# Additional plugins (optional)
+# Disable plugins (default: oh-my-opencode, @tarquinen/opencode-dcp)
 plugins:
-  enabled: true
-  npm: []
-  # Example: ["@tarquinen/opencode-dcp@latest"]
+  enabled: false
 ```
 
 ---

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -116,7 +116,7 @@ serverPassword: "change-me"
 
 # -- Oh-My-OpenCode configuration
 omo:
-  enabled: false
+  enabled: true
   sisyphus:
     maxConcurrentTasks: 2
     taskTimeout: 300
@@ -135,11 +135,13 @@ omo:
 # -- MCP server configuration
 mcp:
   # -- Remote MCP servers (URLs accessible from the cluster)
-  remote: []
-  # - name: context7
-  #   url: https://mcp.context7.com/mcp
-  #   enabled: true
-  #   headers: {}
+  remote:
+    - name: context7
+      url: https://mcp.context7.com/mcp
+      enabled: true
+  # - name: sentry
+  #   url: https://mcp.sentry.dev/mcp
+  #   enabled: false
   #   oauth: {}
 
   # -- Laptop MCP servers (reachable via Tailscale cluster egress)
@@ -169,9 +171,15 @@ opencode:
 # -- Skills configuration for OpenCode
 # -- Skills are reusable prompt templates and tool configurations
 skills:
-  # -- npm-based skills to install (array of npm package specifiers)
-  # -- Example: ["@my-org/skills@latest"]
-  npm: []
+  # -- npm-based skills to install
+  # -- These are user-installed skills that override built-in defaults
+  npm:
+    - CORE
+    - Prompting
+    - Art
+    - CreateSkill
+    - Agents
+    - GitWorkflow
   # -- Inline skill configurations (array of skill config objects)
   # -- See https://opencode.ai/docs/skills/ for format
   config: []

--- a/docs/ai-install.md
+++ b/docs/ai-install.md
@@ -86,17 +86,34 @@ kubectl apply -f https://raw.githubusercontent.com/timothyclin/k8s-opencode/main
 
 ### Single-User Deploy
 
+Defaults now include Oh-My-OpenCode, Context7 MCP, and user skills. Just set your password:
+
 ```yaml
 # values.yaml — fill in serverPassword
 serverPassword: "CHANGE_ME"
 
-# API key optional - run /connect after login to authenticate
-# providers:
-#   anthropic:
-#     enabled: true
-#     apiKey: "sk-ant-your-key"
+# Optional: Override defaults
+# - To disable Oh-My-OpenCode: omo.enabled: false
+# - To disable MCPs: mcp.remote: []
+# - To disable skills: skills.npm: []
 
-# Enable Oh-My-OpenCode (task orchestration with Sisyphus, Oracle, Librarian)
+# Enable Tailscale ingress (recommended)
+ingress:
+  enabled: true
+```
+
+```bash
+helm install ok8s oci://ghcr.io/timothyclin/k8s-opencode/chart/ok8s -n opencode --create-namespace \
+  -f values.yaml
+```
+
+Or with all options explicitly shown (for reference):
+
+```yaml
+# values.yaml — full example with defaults
+serverPassword: "CHANGE_ME"
+
+# Oh-My-OpenCode: enabled by default
 omo:
   enabled: true
   sisyphus:
@@ -114,11 +131,28 @@ omo:
     visualEngineering:
       model: "github-copilot/claude-sonnet-4.6"
 
-# Enable plugins
+# Plugins: enabled by default (oh-my-opencode, @tarquinen/opencode-dcp)
 plugins:
   enabled: true
 
-# Enable Tailscale ingress
+# MCP servers: context7 enabled by default
+mcp:
+  remote:
+    - name: context7
+      url: https://mcp.context7.com/mcp
+      enabled: true
+
+# Skills: CORE, Prompting, Art, CreateSkill, Agents, GitWorkflow by default
+skills:
+  npm:
+    - CORE
+    - Prompting
+    - Art
+    - CreateSkill
+    - Agents
+    - GitWorkflow
+
+# Tailscale ingress
 ingress:
   enabled: true
 


### PR DESCRIPTION
## Summary
- Enable Oh-My-OpenCode by default (`omo.enabled: true`)
- Add context7 MCP server as default (enabled)
- Add default user skills: CORE, Prompting, Art, CreateSkill, Agents, GitWorkflow
- Update README and ai-install.md to reflect new defaults
- Simplify ai-install.md to show minimal config with defaults

## Changes

| Setting | Before | After |
|---------|--------|-------|
| `omo.enabled` | `false` | `true` |
| `mcp.remote` | `[]` | `[context7]` |
| `skills.npm` | `[]` | `[CORE, Prompting, Art, CreateSkill, Agents, GitWorkflow]` |

This brings the chart defaults in line with a standard OpenCode "AI install" experience.