### PR TITLE
feat: enable kubedock by default, add memory/kubedock prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,11 @@ See [chart/values.yaml](chart/values.yaml) for all options. Key sections:
 |---------|---------|
 | `serverPassword` | HTTP auth for the OpenCode server |
 | `opencode.username` | Home directory user (default: opencode) |
+| `resources.limits.memory` | Container memory limit (default: 2Gi) |
 | `mcp.remote[]` | Remote MCP servers (URLs) |
 | `mcp.laptopServers[]` | Laptop MCP servers (via Tailscale egress) |
 | `ingress.enabled` | Expose OpenCode UI to tailnet |
-| `kubedock.*` | Docker API → K8s Pod translation |
+| `kubedock.enabled` | Enable kubedock (default: true) |
 | `persistence.*` | Storage for home dir and workspace |
 
 > **Note:** LLM API keys are optional. After logging in, run `/connect` to authenticate with 75+ providers.

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -283,7 +283,7 @@ identity:
 # -- Kubedock: Docker API to Kubernetes Pod translation layer
 # -- Prevents OOM kills by running test containers as separate Pods instead of DinD sidecars
 kubedock:
-  enabled: false
+  enabled: true
   image:
     repository: joyrex2001/kubedock
     tag: "0.20.3"

--- a/docs/ai-install.md
+++ b/docs/ai-install.md
@@ -40,6 +40,8 @@ If they choose single-user, ask for:
 | Value | How to Get | Example |
 |-------|-----------|---------|
 | `serverPassword` | Ask human | `"my-secret-password"` |
+| Memory limit | Optional — defaults to 2Gi | `"4Gi"` |
+| Kubedock | Optional — defaults to enabled | `false` to disable |
 | Username | Optional — defaults to `opencode` | `"timothy"` |
 
 > **API key is optional** — Don't ask for it. After logging in, run `/connect` to authenticate with 75+ providers.
@@ -50,7 +52,11 @@ If they choose single-user, ask for:
 > "I need 1 value to install single-user k8s-opencode:
 > - `serverPassword` - What password should I set for the OpenCode web UI?
 > 
-> (Optional: What username should I use? Defaults to 'opencode'. This determines your home directory name and your access URL.)"
+> I also have 2 optional settings with sensible defaults. Let me know if you'd like to change either:
+> - **Memory limit**: Defaults to 2Gi. Need more for large projects?
+> - **Kubedock**: Enabled by default (runs test containers as K8s pods). Want to disable?
+> 
+> (Optional: What username should I use? Defaults to 'opencode'. This determines your home directory name and access URL.)"
 
 ### Multi-User Mode
 


### PR DESCRIPTION
## Summary
- Enable kubedock by default (was disabled)
- Update ai-install.md to prompt for memory limit and kubedock options
- Update README config table with new defaults

## Changes

| Setting | Before | After |
|---------|--------|-------|
| `kubedock.enabled` | `false` | `true` |
| `resources.limits.memory` | `2Gi` | `2Gi` (documented) |

The AI now asks during install:
- "Memory limit: defaults to 2Gi. Need more?"
- "Kubedock: enabled by default. Want to disable?"