### PR TITLE
docs: fix AI agent instructions - remove tailnet prompt, use question tool for password

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,14 @@ For AI agents, see [docs/ai-install.md](docs/ai-install.md) for the full install
 
 3. **Then deploy** — Use the recommended values from `docs/ai-install.md`
 
-3. **After install** — Tell human the access URL (derived from their Tailscale tailnet automatically):
+4. **After install** — Tell human the access URL (the tailnet name is determined automatically from the cluster — do NOT ask for it):
    ```
    https://oc-<username>.<tailnet>.ts.net
    # Default username: https://oc-opencode.<tailnet>.ts.net
    Username: (username, defaults to opencode)
    Password: (the serverPassword you set)
    ```
+   > The `<tailnet>` placeholder is filled automatically by Tailscale — you don't need to know it in advance.
 
 ## What This Is
 
@@ -537,11 +538,13 @@ spec:
 
 When a human asks you to install or configure k8s-opencode:
 
-**1. Gather required values first** — Ask the human:
-- `serverPassword` — password for the web UI
-- `<your-tailnet>` — their Tailscale tailnet name (e.g., `example` in `opencode.example.ts.net`)
+**1. Gather required values first** — Use the `question` tool to collect:
+- `serverPassword` — password for the web UI (use a password input field)
+- `username` — optional, defaults to `opencode`
 
 > API key is optional — don't ask. After login, run `/connect` to authenticate.
+> 
+> **Do NOT ask for the Tailscale tailnet name** — it is determined automatically from the cluster.
 
 **2. Use the recommended deploy** — See [docs/ai-install.md](docs/ai-install.md) for the full config with Oh-My-OpenCode enabled.
 

--- a/docs/ai-install.md
+++ b/docs/ai-install.md
@@ -48,15 +48,18 @@ If they choose single-user, ask for:
 > 
 > **Note:** Username determines ingress hostname. For username "alice", URL is `https://oc-alice.<tailnet>.ts.net`. You don't need to ask for the tailnet name.
 
-**Prompt:**
-> "I need 1 value to install single-user k8s-opencode:
-> - `serverPassword` - What password should I set for the OpenCode web UI?
-> 
-> I also have 2 optional settings with sensible defaults. Let me know if you'd like to change either:
-> - **Memory limit**: Defaults to 2Gi. Need more for large projects?
-> - **Kubedock**: Enabled by default (runs test containers as K8s pods). Want to disable?
-> 
-> (Optional: What username should I use? Defaults to 'opencode'. This determines your home directory name and access URL.)"
+**Use the `question` tool to collect values interactively:**
+
+Use your agent's `question` tool to show an interactive form. Collect `serverPassword` as a **password input field** (not plain text). Example questions to ask:
+
+1. `serverPassword` — "What password should I set for the OpenCode web UI?" *(use a password/secret input field)*
+2. `username` — "What username? Defaults to 'opencode'. This sets your home directory and access URL." *(optional, freetext)*
+3. `memoryLimit` — "Memory limit? Defaults to 2Gi. Increase for large projects." *(optional, freetext)*
+4. `kubedock` — "Disable kubedock? It's enabled by default to run test containers as K8s pods." *(optional, yes/no)*
+
+> **Do NOT ask for the Tailscale tailnet name** — it is determined automatically.
+
+If your agent platform does not support interactive input fields, ask for the password in a clearly labeled field and note that it will be used as a secret value.
 
 ### Multi-User Mode
 


### PR DESCRIPTION
## Summary

- **Bug fix**: Removes the erroneous `<your-tailnet>` collection step from the `How to Help (AI Agent)` section in README.md — agents were being told to ask users for their Tailscale tailnet name, which is never needed (it's auto-determined from the cluster)
- **Bug fix**: Replaces the plain-text password prompt template in `docs/ai-install.md` with explicit instructions to use the `question` tool with a **password input field**, so `serverPassword` is collected securely via an interactive form rather than as visible text
- **Clarification**: Adds explicit `Do NOT ask for the Tailscale tailnet name` warnings in two locations in README.md to prevent regressions

## Root Cause

The `How to Help (AI Agent)` section in README.md explicitly instructed agents to collect `<your-tailnet>` as a required value. Agents following the GitHub README (rather than `docs/ai-install.md`) would ask this question unnecessarily. The `docs/ai-install.md` already had the correct guidance ("You don't need to ask for the tailnet name") but the README contradicted it.

The password collection was using a plain prose prompt template with no guidance to use interactive input fields, causing agents to ask for passwords in plain text chat messages.

## Related

Fixes the behavior reported in the shared session: https://opncd.ai/share/VnygoOyO