### PR TITLE
fix: use $USER_GID instead of $USER_ID in useradd -g and chown

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -54,7 +54,7 @@ spec:
           USER_GID="{{ .Values.securityContext.runAsGroup | default 1000 }}"
           
           # Create user with provided name (or fallback)
-          id "$USER_NAME" 2>/dev/null || useradd -u $USER_ID -g $USER_ID -m -d /home/$USER_NAME -s /bin/bash "$USER_NAME"
+          id "$USER_NAME" 2>/dev/null || useradd -u $USER_ID -g $USER_GID -m -d /home/$USER_NAME -s /bin/bash "$USER_NAME"
           
           # Configure sudoers for the runtime user
           echo "$USER_NAME ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/$USER_NAME
@@ -89,7 +89,7 @@ spec:
             done
           fi
           # Best-effort chown (NFS with root_squash may fail)
-          chown -R $USER_ID:$USER_ID /home/$USER_NAME 2>/dev/null || true
+          chown -R $USER_ID:$USER_GID /home/$USER_NAME 2>/dev/null || true
         securityContext:
           runAsUser: 0
           runAsGroup: 0

--- a/chart/templates/statefulset.yaml
+++ b/chart/templates/statefulset.yaml
@@ -65,7 +65,7 @@ spec:
           USER_GID="{{ $root.Values.securityContext.runAsGroup | default 1000 }}"
           
           # Create user with provided name
-          id "$USER_NAME" 2>/dev/null || useradd -u $USER_ID -g $USER_ID -m -d /home/$USER_NAME -s /bin/bash "$USER_NAME"
+          id "$USER_NAME" 2>/dev/null || useradd -u $USER_ID -g $USER_GID -m -d /home/$USER_NAME -s /bin/bash "$USER_NAME"
           
           # Configure sudoers for the runtime user
           echo "$USER_NAME ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/$USER_NAME


### PR DESCRIPTION
## Summary

- `useradd -g $USER_ID` → `useradd -g $USER_GID` in `deployment.yaml` and `statefulset.yaml`
- `chown -R $USER_ID:$USER_ID` → `chown -R $USER_ID:$USER_GID` in `deployment.yaml`

## Root Cause

The identity init container used `$USER_ID` for the `-g` (group) flag of `useradd` and for the group portion of `chown`. The `-g` flag expects a **group name or GID**, not a user ID. When `runAsUser != runAsGroup`, this created users with the wrong primary group.

`statefulset.yaml` already used `$USER_GID` in all its `chown` calls — only the `useradd` line was wrong there.

## Impact

Affects all deployments where `securityContext.runAsUser != securityContext.runAsGroup` (when default 1000/1000 is not used). The user would be created with primary group equal to their UID rather than GID.

Caught by Copilot review on PR #22.