### PR TITLE
ci: remove commit-back-to-main step from publish-chart

### DIFF
--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -6,7 +6,6 @@ on:
       - "v*"
 
 permissions:
-  contents: write
   packages: write
 
 jobs:
@@ -15,9 +14,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: main
-          fetch-depth: 0
 
       - name: Get version from tag
         id: version
@@ -31,22 +27,6 @@ jobs:
           # Update image tags in values.yaml so the packaged chart references the correct image version
           yq -i ".image.tag = \"${{ steps.version.outputs.VERSION }}\"" chart/values.yaml
           yq -i ".auth.router.image.tag = \"${{ steps.version.outputs.VERSION }}\"" chart/values.yaml
-
-      - name: Set up Git
-        run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-          git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}
-
-      - name: Commit version update
-        run: |
-          git add chart/Chart.yaml chart/values.yaml
-          if ! git diff --cached --quiet; then
-            git commit -m "chore: update versions to ${{ steps.version.outputs.VERSION }}"
-            git push origin main
-          else
-            echo "No changes to commit"
-          fi
 
       - name: Set up Helm
         uses: azure/setup-helm@v4


### PR DESCRIPTION
## Summary

- Removes the `contents: write` permission, `ref: main` checkout, "Set up Git", and "Commit version update" steps from `publish-chart.yml`
- The yq version updates now happen in-place before `helm package` without being committed back to the repo
- The packaged OCI chart still gets the correct versions baked in — that's what matters for `helm install`

## Why

`main` is a protected branch requiring PRs + status checks. CI cannot push directly to it. Previous attempts (PR #23) tried `git push origin HEAD:main` which always fails with `GH006: Protected branch update failed`, causing the entire release job to abort before the chart was packaged or pushed.

## Impact

- Version files (`Chart.yaml`, `values.yaml`) in the repo source will no longer be auto-updated on each tag
- The OCI chart artifact **will** have the correct versions (set by yq before packaging)
- Users always install from the OCI artifact, not from source — so this is correct behavior

## Closes

Unblocks the failed `v0.2.4` release. After this merges, push `v0.2.4` tag again to trigger a clean publish.