### PR TITLE
docs: fix AI agent install instructions - question tool for mode selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,17 +538,49 @@ spec:
 
 When a human asks you to install or configure k8s-opencode:
 
-**1. Gather required values first** — Use the `question` tool to collect:
-- `serverPassword` — password for the web UI (use a password input field)
-- `username` — optional, defaults to `opencode`
+**1. Ask deployment mode first** — Use the `question` tool:
+
+```json
+{
+  "questions": [{
+    "question": "Which deployment mode do you want?",
+    "header": "Deployment Mode",
+    "options": [
+      {"label": "Single-user (Recommended)", "description": "Simple Helm install, one OpenCode instance for personal use"},
+      {"label": "Multi-user", "description": "Install Kubernetes operator first, then create isolated workspaces per user"}
+    ]
+  }]
+}
+```
+
+**2. Gather required values** — Use the `question` tool to collect (single-user example):
+
+```json
+{
+  "questions": [
+    {
+      "question": "What password should I set for the OpenCode web UI?",
+      "header": "Server Password",
+      "options": []
+    },
+    {
+      "question": "What username? Defaults to 'opencode'. Sets your home directory and access URL.",
+      "header": "Username (optional)",
+      "options": []
+    }
+  ]
+}
+```
 
 > API key is optional — don't ask. After login, run `/connect` to authenticate.
 > 
 > **Do NOT ask for the Tailscale tailnet name** — it is determined automatically from the cluster.
+> 
+> **Note:** The `question` tool collects free-text answers via "Type your own answer" — there is no masked/password input type. Just label the field clearly as a password/secret.
 
-**2. Use the recommended deploy** — See [docs/ai-install.md](docs/ai-install.md) for the full config with Oh-My-OpenCode enabled.
+**3. Use the recommended deploy** — See [docs/ai-install.md](docs/ai-install.md) for the full config with Oh-My-OpenCode enabled.
 
-**3. Tell them the access URL after install:**
+**4. Tell them the access URL after install:**
 ```
 https://oc-<username>.<tailnet>.ts.net
 # Default username: https://oc-opencode.<tailnet>.ts.net

--- a/docs/ai-install.md
+++ b/docs/ai-install.md
@@ -14,20 +14,20 @@ Before proceeding, verify the human has:
 
 ## Step 1: Ask Deployment Mode
 
-**First, ask the human which mode they want:**
+**Use the `question` tool to ask which mode they want:**
 
-> "k8s-opencode supports two deployment modes:
-> 
-> 1. **Single-user** (recommended for personal use)
->    - Simple Helm install, one OpenCode instance for you
->    - Quick setup, no operator needed
-> 
-> 2. **Multi-user** (for teams/enterprises)
->    - Install the Kubernetes operator first
->    - Creates isolated workspaces per user via Custom Resource Definition
->    - Dynamic provisioning, each user gets their own namespace
-> 
-> Which mode would you like?"
+```json
+{
+  "questions": [{
+    "question": "Which deployment mode do you want?",
+    "header": "Deployment Mode",
+    "options": [
+      {"label": "Single-user (Recommended)", "description": "Simple Helm install, one OpenCode instance for personal use. Quick setup, no operator needed."},
+      {"label": "Multi-user", "description": "Install the Kubernetes operator first. Creates isolated workspaces per user via CRD. Dynamic provisioning, each user gets their own namespace."}
+    ]
+  }]
+}
+```
 
 ---
 
@@ -50,12 +50,37 @@ If they choose single-user, ask for:
 
 **Use the `question` tool to collect values interactively:**
 
-Use your agent's `question` tool to show an interactive form. Collect `serverPassword` as a **password input field** (not plain text). Example questions to ask:
+Use your agent's `question` tool to show an interactive form. The `question` tool collects values as free-text answers ("Type your own answer") — there is no masked/password input type. Label the password field clearly so the human knows it's a secret value. Example:
 
-1. `serverPassword` — "What password should I set for the OpenCode web UI?" *(use a password/secret input field)*
-2. `username` — "What username? Defaults to 'opencode'. This sets your home directory and access URL." *(optional, freetext)*
-3. `memoryLimit` — "Memory limit? Defaults to 2Gi. Increase for large projects." *(optional, freetext)*
-4. `kubedock` — "Disable kubedock? It's enabled by default to run test containers as K8s pods." *(optional, yes/no)*
+```json
+{
+  "questions": [
+    {
+      "question": "What password should I set for the OpenCode web UI? (This will be stored as a Kubernetes secret)",
+      "header": "Server Password",
+      "options": []
+    },
+    {
+      "question": "What username? Defaults to 'opencode'. This sets your home directory and access URL.",
+      "header": "Username (optional)",
+      "options": []
+    },
+    {
+      "question": "Memory limit? Defaults to 2Gi. Increase for large projects (e.g. 4Gi).",
+      "header": "Memory Limit (optional)",
+      "options": []
+    },
+    {
+      "question": "Disable kubedock? It's enabled by default to run test containers as K8s pods.",
+      "header": "Kubedock",
+      "options": [
+        {"label": "Keep enabled (Recommended)", "description": "Run test containers as Kubernetes pods"},
+        {"label": "Disable", "description": "Disable kubedock"}
+      ]
+    }
+  ]
+}
+```
 
 > **Do NOT ask for the Tailscale tailnet name** — it is determined automatically.
 


### PR DESCRIPTION
## Summary

- **Root cause 1: Mode selection missing** — The README 'How to Help (AI Agent)' section jumped straight to gathering `serverPassword` without first asking single vs multi-user. Fixed by adding a Step 1 `question` tool call for mode selection.

- **Root cause 2: Misleading 'password input field' language** — Both README and `docs/ai-install.md` instructed agents to use a "password input field" for `serverPassword`, but the `question` tool has no masked input type — only free-text answers via "Type your own answer". Fixed by replacing this language with accurate description of how the tool works, plus a note for agents to label the field clearly.

- **docs/ai-install.md Step 1** — Replaced the plain prose block with an actual `question` tool JSON invocation example, so agents know exactly how to call it.

## Changes

- `README.md`: Rewrote 'How to Help (AI Agent)' to include mode selection as Step 1, show concrete `question` tool JSON examples, clarify free-text input behavior
- `docs/ai-install.md`: Replaced Step 1 text prompt with `question` tool invocation; replaced bullet list in Step 2 with a concrete `question` tool JSON example; removed all "password input field" language