### PR TITLE
fix: narrow ok8s service selector to exclude kubedock pod

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       labels:
         {{- include "ok8s.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: server
       annotations:
         checksum/config: {{ include "ok8s.opencodeConfig" . | sha256sum }}
         {{- if .Values.omo.enabled }}

--- a/chart/templates/service.yaml
+++ b/chart/templates/service.yaml
@@ -10,6 +10,7 @@ spec:
   type: ClusterIP
   selector:
     {{- include "ok8s.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: server
   ports:
   - name: http
     port: 4096


### PR DESCRIPTION
## Problem

In single-user mode with kubedock enabled, `kubectl port-forward svc/ok8s` fails ~50% of the time (and always fails if you hit the wrong backend).

**Root cause:** The `ok8s` service selector used only `name + instance` labels:
```yaml
selector:
  app.kubernetes.io/name: ok8s
  app.kubernetes.io/instance: ok8s
```

The kubedock pod carries those same labels **plus** `component=kubedock`. Since Kubernetes label selectors match pods with *at least* the specified labels, kubedock was included in the service endpoints:

```
Endpoints: 10.1.122.151:4096 (opencode ✅), 10.1.122.168:4096 (kubedock ❌)
```

Kubedock listens on port 2475, not 4096 — so every other connection to the service would fail.

## Fix

Add `app.kubernetes.io/component: server` to:
1. The main deployment pod template labels (so pods carry this label)
2. The `ok8s` service selector (so only the opencode pod matches)

The deployment `matchLabels` is intentionally left unchanged to avoid the immutable field constraint on existing deployments.

## Verification

```bash
helm template ok8s chart/ --set serverPassword=test --namespace opencode | grep -A 5 'selector:'
# ok8s service selector now includes component: server
# kubedock pod has component: kubedock → no longer selected
```