### PR TITLE
fix: replace hardcoded bitnami/kubectl:1.30 with configurable cleanup job image

### DIFF
--- a/chart/templates/tailscale/cleanup-job.yaml
+++ b/chart/templates/tailscale/cleanup-job.yaml
@@ -35,7 +35,8 @@ spec:
       restartPolicy: Never
       containers:
         - name: cleanup
-          image: bitnami/kubectl:1.30
+          image: "{{ .Values.tailscaleOperator.cleanupJob.image.repository }}:{{ .Values.tailscaleOperator.cleanupJob.image.tag }}"
+          imagePullPolicy: {{ .Values.tailscaleOperator.cleanupJob.image.pullPolicy }}
           command:
             - sh
             - -c

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -197,6 +197,12 @@ tailscaleOperator:
   proxyTag: "tag:k8s"
   # -- Namespace where the Tailscale operator is installed
   namespace: "tailscale"
+  cleanupJob:
+    image:
+      # -- Image for the pre-delete Tailscale cleanup job
+      repository: bitnami/kubectl
+      tag: latest
+      pullPolicy: IfNotPresent
 
 # -- Secret management backend
 # -- Options: "plain" (K8s secrets), "sealed" (Bitnami sealed-secrets), "sops" (Mozilla SOPS), "external" (external-secrets-operator)


### PR DESCRIPTION
## Summary

- `bitnami/kubectl:1.30` has been removed from Docker Hub (Bitnami dropped old tags), causing the pre-delete Tailscale cleanup job to fail with `ImagePullBackOff` on every `helm uninstall`
- This left `ProxyClass/ok8s-egress` stuck with a `tailscale.com/finalizer` (manually cleared on cluster)

## Changes

- **`chart/values.yaml`**: Added `tailscaleOperator.cleanupJob.image` with `repository: bitnami/kubectl`, `tag: latest`, `pullPolicy: IfNotPresent`
- **`chart/templates/tailscale/cleanup-job.yaml`**: Replaced hardcoded `bitnami/kubectl:1.30` with `{{ .Values.tailscaleOperator.cleanupJob.image.repository }}:{{ .Values.tailscaleOperator.cleanupJob.image.tag }}` + `imagePullPolicy` from values

Users can now override the image if needed (e.g. `registry.bitnami.com/bitnami/kubectl:1.32`).