### PR TITLE
feat: seed writable skills from chart/skills/ via idempotent init container copy

### DIFF
--- a/chart/skills/Agents/SKILL.md
+++ b/chart/skills/Agents/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: Agents
+description: Dynamic agent composition and management system. USE WHEN user says create custom agents, spin up custom agents, specialized agents, OR asks for agent personalities, available traits, agent voices. Handles custom agent creation, personality assignment, voice mapping, and parallel agent orchestration.
+---
+
+# Agents - Custom Agent Composition System
+
+**Auto-routes when user mentions custom agents, agent creation, or specialized personalities.**
+
+---
+
+## MANDATORY: AgentFactory Execution (Constitutional Rule)
+
+**BEFORE launching ANY custom agent, you MUST execute AgentFactory.ts via Bash.**
+
+```bash
+# REQUIRED for each custom agent:
+bun run $HOME/.claude/skills/Agents/Tools/AgentFactory.ts \
+  --traits "<expertise>,<personality>,<approach>" \
+  --task "<task description>" \
+  --output json
+```
+
+### Validation Checklist
+
+Before calling `Task()` for custom agents, confirm:
+
+- [ ] I executed `AgentFactory.ts` via Bash for EACH agent
+- [ ] I captured the JSON output (prompt + voice_id)
+- [ ] I am using the factory's `prompt` field verbatim
+- [ ] I am using `subagent_type: "general-purpose"`
+- [ ] Each agent has DIFFERENT trait combinations
+
+### What is FORBIDDEN
+
+| Action | Why It's Wrong |
+|--------|----------------|
+| Reading Traits.yaml and manually composing prompts | Bypasses voice mapping and template |
+| Copy-pasting trait descriptions into Task prompts | Creates inconsistent agent format |
+| Using `subagent_type: "Intern"` for custom agents | Overrides custom voice assignment |
+| Same traits for multiple agents | All agents get same voice |
+
+**If you haven't run AgentFactory.ts in this conversation, you have NOT created custom agents.**
+
+### Error Recovery Protocol
+
+**If AgentFactory returns "Unknown traits" error:**
+
+1. **DO NOT guess again** - Don't try different trait names randomly
+2. **Read the error output** - AgentFactory now lists all available traits on error
+3. **Select valid traits** - Choose from EXPERTISE, PERSONALITY, and APPROACH categories
+4. **Retry with correct traits** - Use the valid trait names from the error message
+
+**Example error output:**
+```
+Error: Unknown traits: typescript, bash
+
+Available traits:
+  EXPERTISE:   security, legal, finance, medical, technical, research, creative, business, data, communications
+  PERSONALITY: skeptical, enthusiastic, cautious, bold, analytical, creative, empathetic, contrarian, pragmatic, meticulous
+  APPROACH:    thorough, rapid, systematic, exploratory, comparative, synthesizing, adversarial, consultative
+
+Run with --list to see full trait descriptions
+```
+
+**Pro tip:** Use `--task` instead of `--traits` to let AgentFactory infer valid traits automatically:
+```bash
+bun run AgentFactory.ts --task "TypeScript transformation with careful type checking" --output json
+```
+
+---
+
+## Overview
+
+The Agents skill provides complete agent composition and management:
+- Dynamic agent composition from traits (expertise + personality + approach)
+- Personality definitions and voice mappings
+- Custom agent creation with unique voices
+- Parallel agent orchestration patterns
+
+## Workflow Routing
+
+**Available Workflows:**
+- **CREATECUSTOMAGENT** - Create specialized custom agents -> `Workflows/CreateCustomAgent.md`
+- **LISTTRAITS** - Show available agent traits -> `Workflows/ListTraits.md`
+- **SPAWNPARALLEL** - Launch parallel agents -> `Workflows/SpawnParallelAgents.md`
+
+## Route Triggers
+
+**CRITICAL: The word "custom" is the ABSOLUTE trigger - NO EXCEPTIONS:**
+
+| User Says | What to Use | subagent_type | Why |
+|-----------|-------------|---------------|-----|
+| "**custom agents**", "create **custom** agents", "spin up **custom**" | AgentFactory | `general-purpose` | Unique prompts + unique voices |
+| "agents", "launch agents", "bunch of agents" | Generic prompt | `Intern` | Same voice, parallel grunt work |
+| "use [agent name]", "get [agent name] to" | Direct call | Named agent type | Pre-defined personality |
+
+**CONSTITUTIONAL RULE FOR CUSTOM AGENTS:**
+When user says "custom agents", you MUST:
+1. Execute AgentFactory.ts via Bash for EACH agent with DIFFERENT traits
+2. Capture and use the JSON output (prompt + voice_id)
+3. Use `subagent_type: "general-purpose"` - **NEVER** "Intern", "Designer", "Architect", etc.
+4. Each agent gets their own voice from the trait-to-voice mapping
+
+## Architecture
+
+### Hybrid Agent Model
+
+Two types of agents:
+
+| Type | Definition | Best For |
+|------|------------|----------|
+| **Named Agents** | Persistent identities with backstories | Recurring work, voice output |
+| **Dynamic Agents** | Task-specific specialists from traits | One-off tasks, parallel work |
+
+### Components
+
+**Data/Traits.yaml** - 28 composable traits with voice mappings
+**Templates/DynamicAgent.hbs** - Agent prompt template
+**Tools/AgentFactory.ts** - Dynamic composition engine
+**AgentPersonalities.md** - Named agent definitions
+
+## Usage
+
+Just ask naturally:
+- "I need a legal expert to review this contract"
+- "Spin up 5 custom science agents"
+- "Get me someone skeptical about security"
+
+The skill routes to appropriate workflow automatically.
+
+## Model Selection
+
+| Task Type | Model | Why |
+|-----------|-------|-----|
+| Grunt work | `haiku` | 10-20x faster |
+| Standard analysis | `sonnet` | Balanced |
+| Deep reasoning | `opus` | Maximum intelligence |

--- a/chart/skills/Art/SKILL.md
+++ b/chart/skills/Art/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: Art
+description: Visual content generation with Excalidraw hand-drawn aesthetic. USE WHEN user wants diagrams, visualizations, comics, or editorial illustrations.
+---
+
+# Art Skill
+
+Visual content generation system using **Excalidraw hand-drawn** aesthetic with dark-mode, tech-forward color palette.
+
+## Output Location
+
+```
+ALL GENERATED IMAGES GO TO ~/Downloads/ FIRST
+Preview in Finder/Preview before final placement
+Only copy to project directories after review
+```
+
+## Workflow Routing
+
+Route to the appropriate workflow based on the request:
+
+  - Technical or architecture diagram -> `Workflows/TechnicalDiagrams.md`
+  - Blog header or editorial illustration -> `Workflows/Essay.md`
+  - Comic or sequential panels -> `Workflows/Comics.md`
+
+---
+
+## Core Aesthetic
+
+**Excalidraw Hand-Drawn** - Clean, approachable technical illustrations with:
+- Slightly wobbly hand-drawn lines (NOT perfect vectors)
+- Simple shapes with organic imperfections
+- Consistent hand-lettered typography style
+- Dark mode backgrounds with bright accents
+
+**Full aesthetic documentation:** `$PAI_DIR/skills/Art/Aesthetic.md`
+
+---
+
+## Color System
+
+| Color | Hex | Usage |
+|-------|-----|-------|
+| Background | `#0a0a0f` | Primary dark background |
+| PAI Blue | `#4a90d9` | Key elements, primary accents |
+| Electric Cyan | `#22d3ee` | Flows, connections, secondary |
+| Accent Purple | `#8b5cf6` | Highlights, callouts (10-15%) |
+| Text White | `#e5e7eb` | Primary text, labels |
+| Surface | `#1a1a2e` | Cards, panels |
+| Line Work | `#94a3b8` | Hand-drawn borders |
+
+---
+
+## Image Generation
+
+**Default model:** nano-banana-pro (Gemini 3 Pro)
+
+```bash
+bun run $PAI_DIR/skills/Art/Tools/Generate.ts \
+  --model nano-banana-pro \
+  --prompt "[PROMPT]" \
+  --size 2K \
+  --aspect-ratio 16:9 \
+  --output ~/Downloads/output.png
+```
+
+**API keys in:** `$PAI_DIR/.env` (single source of truth for all authentication)
+
+---
+
+## Examples
+
+**Example 1: Technical diagram**
+```
+User: "create a diagram showing the auth flow"
+-> Invokes TECHNICALDIAGRAMS workflow
+-> Creates Excalidraw-style architecture visual
+-> Outputs PNG with dark background, blue accents
+```
+
+**Example 2: Blog header**
+```
+User: "create a header for my post about AI agents"
+-> Invokes ESSAY workflow
+-> Generates hand-drawn illustration
+-> Saves to ~/Downloads/ for preview
+```
+
+**Example 3: Comic strip**
+```
+User: "create a comic showing the before/after of using AI"
+-> Invokes COMICS workflow
+-> Creates 3-4 panel sequential narrative
+-> Editorial style, not cartoonish
+```

--- a/chart/skills/CORE/SKILL.md
+++ b/chart/skills/CORE/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: CORE
+description: Personal AI Infrastructure core. AUTO-LOADS at session start. USE WHEN any session begins OR user asks about identity, response format, contacts, stack preferences, security protocols, or asset management.
+---
+
+# CORE - Personal AI Infrastructure
+
+**Auto-loads at session start.** This skill defines your AI's identity, response format, and core operating principles.
+
+## Identity
+
+**Assistant:**
+- Name: Tai
+- Role: Timothy's AI assistant
+- Operating Environment: Personal AI infrastructure built on Claude Code
+
+**User:**
+- Name: Timothy
+
+---
+
+## First-Person Voice (CRITICAL)
+
+Your AI should speak as itself, not about itself in third person.
+
+**Correct:**
+- "for my system" / "in my architecture"
+- "I can help" / "my delegation patterns"
+- "we built this together"
+
+**Wrong:**
+- "for Tai" / "for the Tai system"
+- "the system can" (when meaning "I can")
+
+---
+
+## Stack Preferences
+
+Default preferences (customize in CoreStack.md):
+
+- **Language:** TypeScript preferred over Python
+- **Package Manager:** bun (NEVER npm/yarn/pnpm)
+- **Runtime:** Bun
+- **Markup:** Markdown (NEVER HTML for basic content)
+
+---
+
+## Response Format (Optional)
+
+Define a consistent response format for task-based responses:
+
+```
+📋 SUMMARY: [One sentence]
+🔍 ANALYSIS: [Key findings]
+⚡ ACTIONS: [Steps taken]
+✅ RESULTS: [Outcomes]
+➡️ NEXT: [Recommended next steps]
+```
+
+Customize this format in SKILL.md to match your preferences.
+
+---
+
+## Workflow Routing
+
+| Workflow | Trigger | File |
+|----------|---------|------|
+| **UpdateDocumentation** | "update architecture", "refresh PAI state" | `Workflows/UpdateDocumentation.md` |
+
+## Examples
+
+**Example: Check contact information**
+```
+User: "What's Angela's email?"
+→ Reads Contacts.md
+→ Returns contact information
+```
+
+**Example: Update PAI architecture**
+```
+User: "Update my PAI architecture"
+→ Invokes UpdateDocumentation workflow
+→ Regenerates PaiArchitecture.md
+```
+
+---
+
+## Quick Reference
+
+**Full documentation:**
+- Skill System: `SkillSystem.md`
+- Architecture: `PaiArchitecture.md` (auto-generated)
+- Contacts: `Contacts.md`
+- Stack preferences: `CoreStack.md`
+- Security protocols: `SecurityProtocols.md`

--- a/chart/skills/CreateSkill/SKILL.md
+++ b/chart/skills/CreateSkill/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: CreateSkill
+description: Create and validate skills. USE WHEN create skill, new skill, skill structure, canonicalize. SkillSearch('createskill') for docs.
+---
+
+# CreateSkill
+
+MANDATORY skill creation framework for ALL skill creation requests.
+
+## Authoritative Source
+
+**Before creating ANY skill, READ:** `$PAI_DIR/skills/CORE/SkillSystem.md`
+
+This document contains the complete specification for:
+- Skill directory structure
+- SKILL.md format and required sections
+- Workflow file conventions
+- Naming conventions (TitleCase)
+- Examples section requirements
+
+## How to Create a Skill
+
+1. **Read the spec:** `$PAI_DIR/skills/CORE/SkillSystem.md`
+2. **Create directory:** `$PAI_DIR/skills/SkillName/`
+3. **Create SKILL.md** with required frontmatter and sections
+4. **Add Workflows/** directory if needed
+5. **Validate** by checking all workflow references resolve
+
+## How to Validate a Skill
+
+Run the pack validator:
+```bash
+bun run $PAI_DIR/tools/validate-pack.ts
+```
+
+Or manually check:
+- SKILL.md exists with valid frontmatter
+- All `Workflows/*.md` references in SKILL.md exist
+- Examples section is present
+
+## How to Canonicalize a Skill
+
+1. Rename files/directories to TitleCase
+2. Ensure SKILL.md has required sections
+3. Verify workflow references resolve
+4. Add Examples section if missing
+
+## Examples
+
+**Example 1: Create a new skill**
+```
+User: "Create a skill for managing my recipes"
+→ Read SkillSystem.md for structure
+→ Create $PAI_DIR/skills/Recipes/SKILL.md
+→ Use TitleCase naming throughout
+```
+
+**Example 2: Fix an existing skill**
+```
+User: "Canonicalize the daemon skill"
+→ Rename files to TitleCase
+→ Ensure Examples section exists
+→ Validate workflow references
+```

--- a/chart/skills/DelegationRecovery/SKILL.md
+++ b/chart/skills/DelegationRecovery/SKILL.md
@@ -1,0 +1,191 @@
+---
+name: DelegationRecovery
+description: Enforces proper delegation failure recovery with user pause for repeated failures. AUTO-LOADS at session start. USE WHEN subagent fails, delegation fails, files missing after task completion, or verification fails.
+---
+
+# DelegationRecovery - Subagent Failure Recovery Protocol
+
+**Auto-loads at session start.** This skill enforces proper recovery when delegated subagents fail to deliver.
+
+---
+
+## CRITICAL: Why This Exists
+
+Sisyphus's default behavior correctly delegates work to subagents, but when subagents report completion without delivering (missing files, broken tests), the fallback is direct implementation. This skill provides explicit recovery rules and a pause mechanism for repeated failures.
+
+---
+
+## Subagent Failure Recovery (MANDATORY)
+
+### Step 1: Detect Failure
+
+A subagent has failed when:
+- Task reports completion but files don't exist
+- Expected deliverables are missing
+- Tests fail after subagent reports success
+- Files exist but in wrong location
+
+### Step 2: Re-Delegate (FIRST ATTEMPT)
+
+**ALWAYS re-delegate with `session_id` before direct implementation:**
+
+```typescript
+// CORRECT: Continue the same session with fix instruction
+task(
+  session_id="ses_xxx",  // SAME session - preserves context
+  category="deep",
+  load_skills=[],
+  prompt="Fix: The files were not created in the correct location.
+- Previous attempt created files in worktree instead of main repo
+- REQUIRED: Create files in [correct path]
+- Verify with: pnpm test after creation"
+)
+```
+
+**Re-delegation prompt MUST include:**
+1. What went wrong (specific error)
+2. Correct location/path (exact)
+3. Verification step (test command, file check)
+
+### Step 3: Second Failure = PAUSE FOR USER
+
+**If re-delegation fails a SECOND time:**
+
+```
+🚨 DELEGATION FAILURE DETECTED
+
+Task: [task name]
+Subagent Session: [session_id]
+Attempts: 2
+
+What I tried:
+1. [First delegation - what happened]
+2. [Second delegation - what happened]
+
+What's still broken:
+- [Specific issue]
+
+⏸️ PAUSING FOR USER DIRECTION
+
+Options:
+1. Debug with me - I'll investigate the root cause
+2. Different approach - suggest an alternative strategy
+3. Direct implementation - authorize me to implement directly (not recommended)
+
+How would you like to proceed?
+```
+
+### Step 4: Direct Implementation (ONLY AFTER USER AUTHORIZATION)
+
+Direct implementation is acceptable ONLY when:
+
+| Condition | Authorization Required |
+|-----------|----------------------|
+| Re-delegation failed twice | User must explicitly authorize |
+| Single-line fix (typo, missing import) | No authorization needed |
+| Environment commands (git status, pnpm test) | No authorization needed |
+| Git operations (commit, push) | No authorization needed |
+| User explicitly requests direct work | User authorization = request itself |
+
+---
+
+## Verification After Every Delegation
+
+After any `task()` completes, verify before proceeding:
+
+```typescript
+// Step 1: Check files exist
+const files = glob("expected/path/**/*")
+
+// Step 2: If missing, re-delegate
+if (files.length === 0) {
+  task(session_id="ses_xxx", prompt="Fix: Files not created...")
+}
+
+// Step 3: Run tests
+bash({ command: "pnpm test" })
+
+// Step 4: If tests fail, re-delegate
+task(session_id="ses_xxx", prompt="Fix: Tests failing in [file]...")
+```
+
+---
+
+## Failure Tracking
+
+Track failures per session:
+
+```
+Session: ses_xxx
+Task: Create classifier.ts
+Attempt 1: Files not created
+Attempt 2: Files in wrong location
+Status: PAUSED - awaiting user direction
+```
+
+---
+
+## Anti-Patterns (FORBIDDEN)
+
+| Action | Why Forbidden |
+|--------|---------------|
+| Direct `write` after subagent fails | Bypasses delegation |
+| Direct `edit` to fix subagent's code | Should re-delegate fix |
+| Skipping verification | Leads to broken state |
+| Third re-delegation without pause | Wastes tokens, need user input |
+| Implementing after 1 failure | Should always try re-delegation first |
+
+---
+
+## Workflow Routing
+
+| Workflow | Trigger | File |
+|----------|---------|------|
+| **RecoverFailedTask** | subagent completes but deliverables missing | `Workflows/RecoverFailedTask.md` |
+| **PauseForUser** | repeated delegation failures | `Workflows/PauseForUser.md` |
+
+---
+
+## Examples
+
+**Example 1: Files not created**
+```
+Subagent task_abc reports completion
+→ glob("packages/agent/src/classifier.ts") returns empty
+→ Re-delegate: task(session_id="ses_xxx", prompt="Fix: classifier.ts not created...")
+→ Second failure
+→ PAUSE: Show user what failed, ask for direction
+```
+
+**Example 2: Wrong location**
+```
+Subagent creates files in worktree instead of main repo
+→ glob finds files in .worktrees/phase2/
+→ Re-delegate: task(session_id="ses_xxx", prompt="Fix: Files created in wrong location...")
+→ If fixes: Continue
+→ If fails: PAUSE
+```
+
+**Example 3: Tests failing**
+```
+Subagent creates files but tests fail
+→ Re-delegate: task(session_id="ses_xxx", prompt="Fix: Tests failing in classifier.test.ts...")
+→ If fixes: Continue
+→ If fails: PAUSE
+```
+
+---
+
+## Quick Reference
+
+**Re-delegation pattern:**
+```
+task(session_id="ses_xxx", prompt="Fix: [specific issue]. [correct location]. [verification step]")
+```
+
+**Pause pattern:**
+```
+🚨 DELEGATION FAILURE DETECTED
+⏸️ PAUSING FOR USER DIRECTION
+[Show options]
+```

--- a/chart/skills/GitWorkflow/SKILL.md
+++ b/chart/skills/GitWorkflow/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: GitWorkflow
+description: Enforces safe git branching workflow. USE WHEN making code changes, editing files, or committing. MANDATORY worktrees for ALL editing tasks — multiple agent sessions may be concurrent.
+---
+
+# GitWorkflow
+
+Enforces the project's git branching protocol before any code changes.
+
+## Core Principle: Worktrees Are MANDATORY
+
+**Every editing task MUST use a worktree.** No exceptions.
+
+**Why:** At any given time, multiple agent sessions may be working concurrently on the same repository. Even a "simple" single-file edit is a potential race condition with another session's work.
+
+- Worktrees provide complete isolation
+- Each session works in its own directory
+- No risk of one session's uncommitted changes conflicting with another's
+- Integration is explicit and deliberate
+
+## Workflow Routing
+
+| Workflow | Trigger | File |
+|----------|---------|------|
+| **BeforeChanges** | Before editing any code file | `Workflows/BeforeChanges.md` |
+| **Commit** | Before committing changes | `Workflows/Commit.md` |
+| **Cleanup** | After merge/PR completion | `Workflows/Cleanup.md` |
+
+## Rules
+
+### MANDATORY Checks (STOP if violated)
+
+1. **NEVER** commit directly to `main` or `master`
+2. **NEVER** edit files in the main repository directory
+3. **ALWAYS** create a worktree before editing ANY file
+4. **ALWAYS** integrate work before removing worktree
+5. **ALWAYS** run tests, lint, build before committing
+
+### Worktree Workflow (MANDATORY for ALL edits)
+
+```bash
+# 1. Create worktree with new branch
+git worktree add ../<repo>-<task-name> -b agent/<task-name>
+
+# 2. Work in the worktree
+cd ../<repo>-<task-name>
+
+# 3. Make changes, commit frequently
+git add . && git commit -m "feat: description"
+
+# 4. When done: integrate to target branch
+cd /path/to/main/repo
+git checkout <target-branch>
+git merge agent/<task-name>
+
+# 5. Only then: cleanup
+git worktree remove ../<repo>-<task-name>
+```
+
+### NO Fallback to Single-Directory Branching
+
+~~Branch fallback is NOT allowed.~~ Even for "trivial" tasks:
+
+- Another session might be working in the main repo
+- Your branch switch could interrupt their work
+- Uncommitted changes from either session could be lost
+
+**Every edit = worktree. No exceptions.**
+
+## Pre-Work Checklist
+
+Before starting ANY code changes:
+
+```bash
+# 1. Check for existing worktrees
+git worktree list
+
+# 2. Check recent agent branches (may indicate other sessions)
+git branch -a --sort=-committerdate | grep -E "agent/|feat/" | head -10
+
+# 3. Confirm you're about to create a NEW worktree
+```
+
+| Finding | Action |
+|---------|--------|
+| Existing worktrees | **WARN** user — another session may be active |
+| In main repo directory | **STOP** — must create worktree first |
+| Already in a worktree | **PROCEED** if it's YOUR worktree for THIS task |
+
+## Cross-Session Awareness
+
+When starting work:
+
+```bash
+git worktree list
+```
+
+If you see active worktrees:
+1. **WARN** user: "I see worktree 'X' — another session may be working"
+2. **ASK**: "Should I create a separate worktree, or coordinate with that work?"
+3. **NEVER** assume the other worktree is abandoned
+
+## Conflict Detection = STOP (CRITICAL)
+
+**If you see ANY sign of concurrent work, STOP and verify.** Signs include:
+
+- Stash conflicts or stash entries you didn't create
+- Merge conflicts when pulling/merging
+- "Your branch has diverged" messages
+- Uncommitted changes you didn't make
+- Recent commits from another session/agent
+
+**WRONG response:**
+```
+"The stash conflict is from the concurrent session's work — not my concern."
+```
+
+**CORRECT response:**
+```
+⚠️ I detected signs of concurrent work:
+- [describe what you saw: stash conflict, merge conflict, etc.]
+
+Before proceeding, I need to verify:
+1. Am I in a worktree? (I should be)
+2. Is the other session also in a worktree?
+3. Are we working on conflicting changes?
+
+[Run git worktree list, git status, git stash list]
+
+If BOTH sessions are in separate worktrees → safe to proceed independently.
+If EITHER session is in main repo → STOP and coordinate with user.
+```
+
+**Why this matters:**
+- "Not my concern" attitude is how work gets lost
+- Conflicts are SIGNALS that isolation may have failed
+- Taking 30 seconds to verify saves hours of lost work
+- The other session's work IS your concern if you're about to overwrite it
+
+## Integration Before Cleanup (CRITICAL)
+
+**NEVER** remove a worktree without integrating the work:
+
+```bash
+# WRONG: Destroys work
+git worktree remove ../<repo>-<task>
+
+# CORRECT: Integrate first
+cd /path/to/main/repo
+git checkout <target-branch>
+git merge agent/<task-name>
+# Verify commits are present
+git log --oneline -5
+# THEN cleanup
+git worktree remove ../<repo>-<task>
+```
+
+## Examples
+
+**Example 1: Any edit (even single file)**
+```
+User: "Fix typo in README"
+→ MUST use worktree (another session might be working)
+→ git worktree add ../myrepo-fix-typo -b agent/fix-typo
+→ cd ../myrepo-fix-typo
+→ Make edit, commit
+→ Merge to target branch
+→ Cleanup worktree
+```
+
+**Example 2: Multi-file task**
+```
+User: "Implement auth flow"
+→ git worktree add ../myrepo-auth -b agent/auth
+→ cd ../myrepo-auth
+→ Implement across multiple files
+→ Commit each logical unit
+→ Merge to target branch
+→ Cleanup worktree
+```
+
+**Example 3: Detecting parallel work**
+```
+→ git worktree list shows: ../myrepo-operator-work
+→ "I see worktree 'myrepo-operator-work'. Another session may be active."
+→ "I'll create a separate worktree for my task to avoid conflicts."
+→ git worktree add ../myrepo-my-task -b agent/my-task
+```
+
+## Integration
+
+This skill should be loaded at session start. Add to your skill configuration:
+
+```json
+{
+  "auto_load": ["GitWorkflow"]
+}
+```

--- a/chart/skills/Prompting/SKILL.md
+++ b/chart/skills/Prompting/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: Prompting
+description: Meta-prompting system for dynamic prompt generation using templates, standards, and patterns. USE WHEN meta-prompting, template generation, prompt optimization, or programmatic prompt composition.
+---
+
+# Prompting - Meta-Prompting & Template System
+
+**Invoke when:** meta-prompting, template generation, prompt optimization, programmatic prompt composition, creating dynamic agents, generating structured prompts from data.
+
+## Overview
+
+The Prompting skill owns ALL prompt engineering concerns:
+- **Standards** - Anthropic best practices, Claude 4.x patterns, empirical research
+- **Templates** - Handlebars-based system for programmatic prompt generation
+- **Tools** - Template rendering, validation, and composition utilities
+- **Patterns** - Reusable prompt primitives and structures
+
+## Workflow Routing
+
+| Workflow | Trigger | File |
+|----------|---------|------|
+| **RenderTemplate** | "render template", "generate from template" | CLI tool |
+| **ValidateTemplate** | "validate template", "check template syntax" | CLI tool |
+| **ApplyStandards** | "review prompt", "optimize prompt" | Reference Standards.md |
+
+## Core Components
+
+### 1. Standards.md
+Complete prompt engineering documentation based on:
+- Anthropic's Claude 4.x Best Practices (November 2025)
+- Context engineering principles
+- 1,500+ academic papers on prompt optimization
+
+### 2. Templates/
+Five core primitives for programmatic prompt generation:
+
+| Primitive | Purpose |
+|-----------|---------|
+| **ROSTER** | Agent/skill definitions from data |
+| **VOICE** | Personality calibration settings |
+| **STRUCTURE** | Multi-step workflow patterns |
+| **BRIEFING** | Agent context handoff |
+| **GATE** | Validation checklists |
+
+### 3. Tools/
+
+**RenderTemplate.ts** - Core rendering engine
+```bash
+bun run $PAI_DIR/skills/Prompting/Tools/RenderTemplate.ts \
+  --template Primitives/Briefing.hbs \
+  --data path/to/data.yaml \
+  --output path/to/output.md
+```
+
+**ValidateTemplate.ts** - Template syntax checker
+```bash
+bun run $PAI_DIR/skills/Prompting/Tools/ValidateTemplate.ts \
+  --template Primitives/Briefing.hbs
+```
+
+## Examples
+
+**Example 1: Generate agent roster**
+```
+User: "Generate a roster from my agents.yaml"
+-> Uses RenderTemplate with Roster.hbs
+-> Outputs formatted agent definitions
+```
+
+**Example 2: Create briefing for research agent**
+```
+User: "Brief the research agent on this task"
+-> Uses RenderTemplate with Briefing.hbs
+-> Generates complete agent context handoff
+```
+
+**Example 3: Validate template syntax**
+```
+User: "Check my new template for errors"
+-> Uses ValidateTemplate
+-> Reports syntax issues, missing variables
+```
+
+## Best Practices
+
+1. **Separation of Concerns** - Templates for structure, YAML for content
+2. **Keep Templates Simple** - Business logic in TypeScript, not templates
+3. **DRY Principle** - Extract repeated patterns into partials
+4. **Validate Before Rendering** - Check all required variables exist
+
+## References
+
+- `Standards.md` - Complete prompt engineering guide
+- `Templates/README.md` - Template system overview
+- `Tools/RenderTemplate.ts` - Implementation details

--- a/chart/templates/configmap-skills.yaml
+++ b/chart/templates/configmap-skills.yaml
@@ -1,0 +1,21 @@
+{{- if and (eq .Values.mode "single") (or .Values.skills.defaults .Values.skills.custom) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "ok8s.fullname" . }}-skills
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "ok8s.labels" . | nindent 4 }}
+data:
+  {{- range .Values.skills.defaults }}
+  {{- $content := $.Files.Get (printf "skills/%s/SKILL.md" .) }}
+  {{- if $content }}
+  {{ . }}: |
+    {{- $content | nindent 4 }}
+  {{- end }}
+  {{- end }}
+  {{- range $name, $content := .Values.skills.custom }}
+  {{ $name }}: |
+    {{- $content | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -89,6 +89,20 @@ spec:
               fi
             done
           fi
+          # Seed skills: copy from ConfigMap to PVC only if not already present (preserves user edits)
+          if [ -d /tmp/skills-source ] && [ "$(ls -A /tmp/skills-source 2>/dev/null)" ]; then
+            mkdir -p /home/$USER_NAME/.config/opencode/skills
+            for f in /tmp/skills-source/*; do
+              [ -f "$f" ] || continue
+              skill_name=$(basename "$f")
+              skill_dir="/home/$USER_NAME/.config/opencode/skills/$skill_name"
+              skill_file="$skill_dir/SKILL.md"
+              if [ ! -e "$skill_file" ]; then
+                mkdir -p "$skill_dir"
+                cp "$f" "$skill_file"
+              fi
+            done
+          fi
           # Best-effort chown (NFS with root_squash may fail)
           chown -R $USER_ID:$USER_GID /home/$USER_NAME 2>/dev/null || true
         securityContext:
@@ -110,6 +124,9 @@ spec:
           mountPath: /etc/sudoers.d/
         - name: passwd
           mountPath: /mnt/passwd
+        - name: skills-init
+          mountPath: /tmp/skills-source
+          readOnly: true
       {{- if .Values.identity.enabled }}
       - name: init-identity
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -241,6 +258,10 @@ spec:
       - name: omo-init
         configMap:
           name: {{ include "ok8s.fullname" . }}-omo
+          optional: true
+      - name: skills-init
+        configMap:
+          name: {{ include "ok8s.fullname" . }}-skills
           optional: true
       {{- if .Values.identity.enabled }}
       - name: identity

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -169,17 +169,37 @@ opencode:
   extraConfig: ""
 
 # -- Skills configuration for OpenCode
-# -- Skills are reusable prompt templates and tool configurations
 skills:
-  # -- npm-based skills to install
-  # -- These are user-installed skills that override built-in defaults
-  npm:
+  # -- Default skill files to seed into ~/.config/opencode/skills/ on first deploy.
+  # -- These SKILL.md files are bundled in chart/skills/ and copied to the writable PVC
+  # -- by the init container. Seeding is idempotent — existing files are never overwritten,
+  # -- so developers can freely modify skills in the pod to customize their workflow.
+  # -- To reset a skill to the chart default: kubectl exec into the pod, delete the file,
+  # -- then restart the pod (or delete the pod).
+  defaults:
     - CORE
     - Prompting
     - Art
     - CreateSkill
     - Agents
     - GitWorkflow
+    - DelegationRecovery
+  # -- Custom inline skill content for private/custom skills not bundled in the chart.
+  # -- Map of skill name to SKILL.md content (string). Same seeding rules apply.
+  # -- Example:
+  #   custom:
+  #     MySkill: |
+  #       ---
+  #       name: MySkill
+  #       description: My custom skill
+  #       ---
+  #       # MySkill
+  #       Instructions here...
+  custom: {}
+  # -- npm-based skills installed via opencode's native npm skill mechanism.
+  # -- Only use this for skills genuinely published as npm packages.
+  # -- The defaults above are file-based; leave this empty unless you have npm-published skills.
+  npm: []
   # -- Inline skill configurations (array of skill config objects)
   # -- See https://opencode.ai/docs/skills/ for format
   config: []


### PR DESCRIPTION
## Summary

- **Problem**: Fresh deployments had no skills in the pod — `~/.config/opencode/skills/` was empty and skills couldn't be loaded by oh-my-opencode. The previous `skills.npm` entries incorrectly referenced local skill names (not npm packages), and the init container never created the skills directory.

- **Solution**: Init-copy pattern — ConfigMap seeds skill files to PVC on first boot (idempotent: skips if file already exists, preserving user edits).

## Changes

- `chart/skills/` — 7 bundled SKILL.md files: CORE, Prompting, Art, CreateSkill, Agents, GitWorkflow, DelegationRecovery
- `chart/templates/configmap-skills.yaml` — New ConfigMap built via `.Files.Get`, supports both `skills.defaults` (chart-bundled) and `skills.custom` (user inline-defined)
- `chart/templates/deployment.yaml` — Init container now idempotently copies skills from `/tmp/skills-source` → `~/.config/opencode/skills/<name>/SKILL.md` on the PVC; skips existing files
- `chart/values.yaml` — Replaced broken `skills.npm` entries with `skills.defaults` list + `skills.custom` map

## Behavior

- **First boot**: All 7 skills are copied to the persistent volume
- **Subsequent boots**: Existing files are left untouched (user edits survive restarts)
- **Reset a skill**: `kubectl exec` into pod, delete the file, restart — it gets re-seeded from the ConfigMap
- **Custom skills**: Add to `skills.custom` in values.yaml as `name: |<content>`