### PR TITLE
feat: add superpowers plugin as default for all deployment modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ mcp:
   remote: []
   laptopServers: []
 
-# Disable plugins (default: oh-my-opencode, @tarquinen/opencode-dcp)
+# Disable plugins (default: oh-my-opencode, @tarquinen/opencode-dcp, superpowers)
 plugins:
   enabled: false
 ```

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -155,13 +155,15 @@ mcp:
 
 # -- Plugin configuration for OpenCode
 # -- Plugins extend OpenCode with additional tools and capabilities
-# -- Default plugins: oh-my-opencode (task orchestration) and @tarquinen/opencode-dcp (design system)
+# -- Default plugins: oh-my-opencode (task orchestration), @tarquinen/opencode-dcp (design system),
+# --   and superpowers (skills framework with brainstorming, TDD, debugging, code review workflows)
 plugins:
   # -- Enable default plugins (set to false to disable all plugins)
   enabled: true
   # -- Additional npm plugins to install (array of npm package specifiers)
   # -- Examples: ["my-plugin@latest", "@scope/plugin@1.0.0"]
-  npm: []
+  npm:
+    - "superpowers@git+https://github.com/obra/superpowers.git"
 
 # -- OpenCode runtime configuration
 opencode:

--- a/docs/ai-install.md
+++ b/docs/ai-install.md
@@ -120,7 +120,7 @@ kubectl apply -f https://raw.githubusercontent.com/timothyclin/k8s-opencode/main
 
 ### Single-User Deploy
 
-Defaults now include Oh-My-OpenCode, Context7 MCP, user skills, kubedock, and 2Gi memory. Just set your password:
+Defaults now include Oh-My-OpenCode, Superpowers skills, Context7 MCP, user skills, kubedock, and 2Gi memory. Just set your password:
 
 ```yaml
 # values.yaml — fill in serverPassword
@@ -185,7 +185,7 @@ omo:
     visualEngineering:
       model: "github-copilot/claude-sonnet-4.6"
 
-# Plugins: enabled by default (oh-my-opencode, @tarquinen/opencode-dcp)
+# Plugins: enabled by default (oh-my-opencode, @tarquinen/opencode-dcp, superpowers)
 plugins:
   enabled: true
 

--- a/docs/customization.md
+++ b/docs/customization.md
@@ -42,12 +42,13 @@ startup and can add new tools, agents, and UI features.
 
 ### Default Plugins
 
-When `plugins.enabled: true` (the default), two plugins are always installed:
+When `plugins.enabled: true` (the default), three plugins are always installed:
 
 | Plugin | Purpose |
 |--------|---------|
 | `oh-my-opencode@latest` | Multi-agent orchestration, Sisyphus task runner |
 | `@tarquinen/opencode-dcp@latest` | Design system and component tools |
+| `superpowers` | Skills framework (brainstorming, TDD, debugging, code review workflows) |
 
 ### Disable Default Plugins
 


### PR DESCRIPTION
## Summary

- Adds [superpowers](https://github.com/obra/superpowers) as a default plugin in `plugins.npm`, alongside oh-my-opencode and @tarquinen/opencode-dcp
- Superpowers provides skills framework with brainstorming, TDD, debugging, code review, and git workflows
- Works for both single-user and multi-user modes (both templates iterate `plugins.npm`)
- Updated docs: customization.md, ai-install.md, README.md

## Changes

| File | Change |
|------|--------|
| `chart/values.yaml` | `plugins.npm` default: `[]` → `["superpowers@git+https://github.com/obra/superpowers.git"]` |
| `docs/customization.md` | Default plugins table: 2 → 3 entries |
| `docs/ai-install.md` | Updated default plugin comments |
| `README.md` | Updated default plugin list in disable example |

## Verification

- `helm lint` passes
- `helm template` renders plugin array correctly with all 3 defaults