### PR TITLE
fix: install uv to /usr/local/bin for non-root user access

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -159,6 +159,8 @@ spec:
         env:
         - name: HOME
           value: "/home/{{ $username }}"
+        - name: UV_TOOL_BIN_DIR
+          value: "/usr/local/bin"
         - name: OPENCODE_SERVER_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/images/workspace/Dockerfile
+++ b/images/workspace/Dockerfile
@@ -83,8 +83,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY --from=opencode-bin /usr/local/bin/opencode /usr/local/bin/opencode
 RUN chmod +x /usr/local/bin/opencode && opencode --version
 
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh && \
-    ln -s /root/.local/bin/uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+RUN chmod +x /usr/local/bin/uv
 
 RUN groupadd -g 1000 appgroup && \
     mkdir -p /home && \


### PR DESCRIPTION
## Summary
- Replace uv installer script with `COPY --from` to copy uv binary directly to `/usr/local/bin`
- Add `UV_TOOL_BIN_DIR` env var to deployment for tool install path
- uv is now accessible to the non-root opencode user (was previously only in /root/.local/bin)

## Changes
- `images/workspace/Dockerfile`: Use `COPY --from=ghcr.io/astral-sh/uv:latest` instead of installer script
- `chart/templates/deployment.yaml`: Add `UV_TOOL_BIN_DIR=/usr/local/bin` env var