### PR TITLE
docs: fix AI agent instructions - explicitly ask all questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,13 +553,15 @@ When a human asks you to install or configure k8s-opencode:
 }
 ```
 
-**2. Gather required values** — Use the `question` tool to collect (single-user example):
+**2. Gather required values** — Use the `question` tool to collect ALL values (single-user example):
+
+> **⚠️ CRITICAL: Ask ALL questions.** Do not skip optional fields — the question tool below is complete for a reason. Defaults are applied automatically if not provided.
 
 ```json
 {
   "questions": [
     {
-      "question": "What password should I set for the OpenCode web UI?",
+      "question": "What password should I set for the OpenCode web UI? (This will be stored as a Kubernetes secret)",
       "header": "Server Password",
       "options": []
     },
@@ -567,6 +569,19 @@ When a human asks you to install or configure k8s-opencode:
       "question": "What username? Defaults to 'opencode'. Sets your home directory and access URL.",
       "header": "Username (optional)",
       "options": []
+    },
+    {
+      "question": "Memory limit? Defaults to 2Gi. Increase for large projects (e.g. 4Gi).",
+      "header": "Memory Limit (optional)",
+      "options": []
+    },
+    {
+      "question": "Disable kubedock? It's enabled by default to run test containers as K8s pods.",
+      "header": "Kubedock",
+      "options": [
+        {"label": "Keep enabled (Recommended)", "description": "Run test containers as Kubernetes pods"},
+        {"label": "Disable", "description": "Disable kubedock"}
+      ]
     }
   ]
 }

--- a/docs/ai-install.md
+++ b/docs/ai-install.md
@@ -35,20 +35,24 @@ Before proceeding, verify the human has:
 
 ### Single-User Mode
 
-If they choose single-user, ask for:
+**MUST ask for ALL of these values** using the question tool — do not skip optional fields:
 
-| Value | How to Get | Example |
-|-------|-----------|---------|
-| `serverPassword` | Ask human | `"my-secret-password"` |
-| Memory limit | Optional — defaults to 2Gi | `"4Gi"` |
-| Kubedock | Optional — defaults to enabled | `false` to disable |
-| Username | Optional — defaults to `opencode` | `"timothy"` |
+| Value | Required | How to Get | Default | Example |
+|-------|----------|-----------|---------|---------|
+| `serverPassword` | ✅ Yes | Ask human | (none) | `"my-secret-password"` |
+| `Username` | ❌ No | Ask human | `"opencode"` | `"timothy"` |
+| Memory limit | ❌ No | Ask human | `"2Gi"` | `"4Gi"` |
+| Kubedock | ❌ No | Ask human | `true` (enabled) | `false` to disable |
+
+> **IMPORTANT:** The question tool MUST include ALL fields — do not skip "optional" fields. Defaults are applied automatically if not provided. Asking ensures the user is aware of configurable options.
 
 > **API key is optional** — Don't ask for it. After logging in, run `/connect` to authenticate with 75+ providers.
 > 
 > **Note:** Username determines ingress hostname. For username "alice", URL is `https://oc-alice.<tailnet>.ts.net`. You don't need to ask for the tailnet name.
 
 **Use the `question` tool to collect values interactively:**
+
+> **⚠️ CRITICAL: Include ALL questions.** Do NOT skip optional fields — defaults are applied automatically. The question tool below includes ALL four fields for a reason. Ask all of them to ensure the user is aware of configurable options.
 
 Use your agent's `question` tool to show an interactive form. The `question` tool collects values as free-text answers ("Type your own answer") — there is no masked/password input type. Label the password field clearly so the human knows it's a secret value. Example:
 


### PR DESCRIPTION
## Summary

- Add explicit 'MUST ask for ALL values' instruction to prevent AI skipping optional fields
- Updated table in ai-install.md with Required column and clearer defaults
- Added critical warning blocks in both README.md and ai-install.md
- Expanded question tool JSON from 2 fields to all 4 fields (password, username, memory, kubedock)

## Issue

AI agents were interpreting 'Optional' fields as 'skip entirely' rather than 'defaults applied if not provided'.