### PR TITLE
fix: add Recreate strategy to prevent PVC multi-attach conflict

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -9,6 +9,8 @@ metadata:
     {{- include "ok8s.labels" . | nindent 4 }}
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "ok8s.selectorLabels" . | nindent 6 }}
@@ -159,6 +161,8 @@ spec:
         env:
         - name: HOME
           value: "/home/{{ $username }}"
+        - name: UV_TOOL_BIN_DIR
+          value: "/usr/local/bin"
         - name: OPENCODE_SERVER_PASSWORD
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
## Summary

Add  to the single-user deployment to prevent the rollout conflict where two pods try to mount the same PVC simultaneously.

## Problem

When  triggers a rollout, Kubernetes creates the new pod BEFORE terminating the old one. Both pods try to mount the same PVCs → "Multi-Attach error" → new pod gets stuck in Init:0/1.

## Solution

Use Recreate strategy so old pod is terminated before new one is created.