### PR TITLE
chore: bump chart version to 0.1.5

### DIFF
--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: ok8s
 description: OpenCode + Oh-My-OpenCode on Kubernetes with Tailscale connectivity
 type: application
-version: 0.1.4
-appVersion: "0.1.4"
+version: 0.1.5
+appVersion: "0.1.5"
 keywords:
   - opencode
   - ai-coding


### PR DESCRIPTION
Bump chart version for Recreate strategy fix.