### PR TITLE
docs: remove obsolete skills from values and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ omo:
     visualEngineering:
       model: "github-copilot/claude-sonnet-4.6"
 
-# Override default skills (defaults: CORE, Prompting, Art, CreateSkill, Agents, GitWorkflow)
+# Override default skills (empty by default - install via npm packages as needed)
 skills:
   npm: []
   config: []

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -175,13 +175,7 @@ opencode:
 skills:
   # -- npm-based skills to install
   # -- These are user-installed skills that override built-in defaults
-  npm:
-    - CORE
-    - Prompting
-    - Art
-    - CreateSkill
-    - Agents
-    - GitWorkflow
+  npm: []
   # -- Inline skill configurations (array of skill config objects)
   # -- See https://opencode.ai/docs/skills/ for format
   config: []

--- a/docs/ai-install.md
+++ b/docs/ai-install.md
@@ -133,7 +133,7 @@ serverPassword: "CHANGE_ME"
 # All defaults are pre-configured:
 # - Oh-My-OpenCode (omo.enabled: true)
 # - Context7 MCP server
-# - Skills: CORE, Prompting, Art, CreateSkill, Agents, GitWorkflow
+# - User skills (empty by default - use npm skill packages)
 # - Kubedock enabled (test containers as K8s pods)
 # - 2Gi memory limit
 # - 20Gi workspace / 5Gi data storage
@@ -200,15 +200,10 @@ mcp:
       url: https://mcp.context7.com/mcp
       enabled: true
 
-# Skills: CORE, Prompting, Art, CreateSkill, Agents, GitWorkflow by default
+# Skills: none by default - install via npm packages as needed
 skills:
-  npm:
-    - CORE
-    - Prompting
-    - Art
-    - CreateSkill
-    - Agents
-    - GitWorkflow
+  npm: []
+  config: []
 
 # Kubedock: enabled by default (runs test containers as K8s pods)
 kubedock:


### PR DESCRIPTION
## Summary

- Remove obsolete skills (CORE, Prompting, Art, CreateSkill, Agents, GitWorkflow) from chart/values.yaml defaults
- Remove obsolete skills references from docs/ai-install.md and README.md
- Skills are now empty by default, users can install via npm packages as needed