### PR TITLE
fix: resolve hardcoded opencode-system namespace in EmailMap reconciliation

### DIFF
--- a/operator/cmd/main.go
+++ b/operator/cmd/main.go
@@ -179,8 +179,9 @@ func main() {
 	}
 
 	if err := (&controller.OpenCodeWorkspaceReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:          mgr.GetClient(),
+		Scheme:          mgr.GetScheme(),
+		SystemNamespace: getSystemNamespace(),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create controller", "controller", "OpenCodeWorkspace")
 		os.Exit(1)
@@ -201,4 +202,11 @@ func main() {
 		setupLog.Error(err, "Failed to run manager")
 		os.Exit(1)
 	}
+}
+
+func getSystemNamespace() string {
+	if ns := os.Getenv("POD_NAMESPACE"); ns != "" {
+		return ns
+	}
+	return "ok8s-system"
 }

--- a/operator/config/manager/manager.yaml
+++ b/operator/config/manager/manager.yaml
@@ -66,6 +66,11 @@ spec:
         image: controller:latest
         name: manager
         ports: []
+        env:
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         securityContext:
           readOnlyRootFilesystem: true
           allowPrivilegeEscalation: false

--- a/operator/internal/controller/opencodeworkspace_controller.go
+++ b/operator/internal/controller/opencodeworkspace_controller.go
@@ -50,7 +50,8 @@ const (
 
 type OpenCodeWorkspaceReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme          *runtime.Scheme
+	SystemNamespace string
 }
 
 // +kubebuilder:rbac:groups=opencode.opencode.io,resources=opencodeworkspaces,verbs=get;list;watch;create;update;patch;delete

--- a/operator/internal/controller/reconcile_emailmap.go
+++ b/operator/internal/controller/reconcile_emailmap.go
@@ -32,9 +32,8 @@ import (
 )
 
 const (
-	emailMapNamespace = "opencode-system"
-	emailMapName      = "email-map"
-	emailMapKey       = "email-map.json"
+	emailMapName = "email-map"
+	emailMapKey  = "email-map.json"
 )
 
 func (r *OpenCodeWorkspaceReconciler) reconcileEmailMap(ctx context.Context, workspace *opencodev1alpha1.OpenCodeWorkspace) error {
@@ -44,7 +43,7 @@ func (r *OpenCodeWorkspaceReconciler) reconcileEmailMap(ctx context.Context, wor
 	}
 
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		key := types.NamespacedName{Name: emailMapName, Namespace: emailMapNamespace}
+		key := types.NamespacedName{Name: emailMapName, Namespace: r.SystemNamespace}
 		configMap := &corev1.ConfigMap{}
 		if err := r.Get(ctx, key, configMap); err != nil {
 			if !apierrors.IsNotFound(err) {
@@ -60,7 +59,7 @@ func (r *OpenCodeWorkspaceReconciler) reconcileEmailMap(ctx context.Context, wor
 			configMap = &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      emailMapName,
-					Namespace: emailMapNamespace,
+					Namespace: r.SystemNamespace,
 				},
 				Data: map[string]string{emailMapKey: string(payload)},
 			}
@@ -111,7 +110,7 @@ func (r *OpenCodeWorkspaceReconciler) removeFromEmailMap(ctx context.Context, wo
 	}
 
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		key := types.NamespacedName{Name: emailMapName, Namespace: emailMapNamespace}
+		key := types.NamespacedName{Name: emailMapName, Namespace: r.SystemNamespace}
 		configMap := &corev1.ConfigMap{}
 		if err := r.Get(ctx, key, configMap); err != nil {
 			if apierrors.IsNotFound(err) {


### PR DESCRIPTION
## Summary

- The operator hardcoded `opencode-system` as the namespace for the EmailMap ConfigMap, but the operator itself is deployed into `ok8s-system`
- This caused 100% of `OpenCodeWorkspace` reconciliations to fail at the EmailMap step with `namespaces "opencode-system" not found`
- Fix reads the operator's own namespace from the `POD_NAMESPACE` env var (downward API), with a fallback to `ok8s-system` for local development

## Changes

- `reconcile_emailmap.go` — remove hardcoded `emailMapNamespace = "opencode-system"` constant; use `r.SystemNamespace` throughout
- `opencodeworkspace_controller.go` — add `SystemNamespace string` field to `OpenCodeWorkspaceReconciler`
- `cmd/main.go` — read `POD_NAMESPACE` env var via `getSystemNamespace()` and wire into reconciler
- `config/manager/manager.yaml` — inject `POD_NAMESPACE` via downward API so the operator self-reports its namespace at runtime

## Testing

- `go build ./...` — clean
- `make test` — all tests pass

## Closes

Fixes: operator fails with `create email-map ConfigMap: namespaces "opencode-system" not found` on every reconcile